### PR TITLE
Navigate the DAG through block children

### DIFF
--- a/processing/database/utils/lrucache/lrucache.go
+++ b/processing/database/utils/lrucache/lrucache.go
@@ -32,7 +32,7 @@ func (c *LRUCache[T]) Add(key *externalapi.DomainHash, value *T) {
 	if len(c.cache) > c.capacity {
 		c.evictRandom()
 	}
-	}
+}
 
 // Get returns the entry for the given key, or (nil, false) otherwise
 func (c *LRUCache[T]) Get(key *externalapi.DomainHash) (*T, bool) {

--- a/processing/infrastructure/config/config.go
+++ b/processing/infrastructure/config/config.go
@@ -1,45 +1,130 @@
 package config
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
 	"github.com/jessevdk/go-flags"
+	"github.com/kaspa-live/kaspa-graph-inspector/processing/infrastructure/logging"
 	kaspaConfigPackage "github.com/kaspanet/kaspad/infrastructure/config"
+	kaspaLogger "github.com/kaspanet/kaspad/infrastructure/logger"
 	"github.com/kaspanet/kaspad/util"
 	"github.com/pkg/errors"
 )
 
 const (
-	appDataDirectory = "kaspa-graph-inspector-processing"
+	appDataDirectory      = "kgi-processing"
+	defaultLogDirname     = "logs"
+	defaultLogLevel       = "info"
+	defaultLogFilename    = "kgi-processing.log"
+	defaultErrLogFilename = "kgi-processing_err.log"
 )
 
 var (
-	HomeDir = util.AppDir(appDataDirectory, false)
+	// DefaultAppDir is the default home directory for kaspad.
+	DefaultAppDir  = util.AppDir(appDataDirectory, false)
+	defaultDataDir = filepath.Join(DefaultAppDir)
 )
 
-type Config struct {
+type Flags struct {
+	AppDir                   string   `short:"b" long:"appdir" description:"Directory to store data"`
+	LogDir                   string   `long:"logdir" description:"Directory to log output."`
 	DatabaseConnectionString string   `long:"connection-string" description:"Connection string for PostgrSQL database to connect to. Should be of the form: postgres://<username>:<password>@<host>:<port>/<database name>"`
 	ConnectPeers             []string `long:"connect" description:"Connect only to the specified peers at startup"`
 	DNSSeed                  string   `long:"dnsseed" description:"Override DNS seeds with specified hostname (Only 1 hostname allowed)"`
 	GRPCSeed                 string   `long:"grpcseed" description:"Hostname of gRPC server for seeding peers"`
 	ClearDB                  bool     `long:"clear-db" description:"Clear the postgres database and resync from scratch"`
+	LogLevel                 string   `short:"d" long:"loglevel" description:"Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the log level for individual subsystems -- Use show to list available subsystems"`
 	kaspaConfigPackage.NetworkFlags
 }
 
-func Parse() (*Config, error) {
-	config := &Config{}
-	parser := flags.NewParser(config, flags.HelpFlag)
-	_, err := parser.Parse()
-	if err != nil {
-		return nil, err
+type Config struct {
+	*Flags
+}
+
+// cleanAndExpandPath expands environment variables and leading ~ in the
+// passed path, cleans the result, and returns it.
+func cleanAndExpandPath(path string) string {
+	// Expand initial ~ to OS specific home directory.
+	if strings.HasPrefix(path, "~") {
+		homeDir := filepath.Dir(DefaultAppDir)
+		path = strings.Replace(path, "~", homeDir, 1)
 	}
 
-	if config.DatabaseConnectionString == "" {
+	// NOTE: The os.ExpandEnv doesn't work with Windows-style %VARIABLE%,
+	// but they variables can still be expanded via POSIX-style $VARIABLE.
+	return filepath.Clean(os.ExpandEnv(path))
+}
+
+func defaultFlags() *Flags {
+	return &Flags{
+		AppDir:   defaultDataDir,
+		LogLevel: defaultLogLevel,
+	}
+}
+
+func LoadConfig() (*Config, error) {
+	funcName := "loadConfig"
+	appName := filepath.Base(os.Args[0])
+	appName = strings.TrimSuffix(appName, filepath.Ext(appName))
+	usageMessage := fmt.Sprintf("Use %s -h to show usage", appName)
+
+	cfgFlags := defaultFlags()
+	parser := flags.NewParser(cfgFlags, flags.HelpFlag)
+	_, err := parser.Parse()
+	if err != nil {
+		var flagsErr *flags.Error
+		if ok := errors.As(err, &flagsErr); !ok || flagsErr.Type != flags.ErrHelp {
+			return nil, errors.Wrapf(err, "Error parsing command line arguments: %s\n\n%s", err, usageMessage)
+		}
+		return nil, err
+	}
+	cfg := &Config{
+		Flags: cfgFlags,
+	}
+
+	if cfg.DatabaseConnectionString == "" {
 		return nil, errors.Errorf("--connection-string is required.")
 	}
 
-	err = config.ResolveNetwork(parser)
+	err = cfg.ResolveNetwork(parser)
 	if err != nil {
 		return nil, err
 	}
 
-	return config, nil
+	cfg.AppDir = cleanAndExpandPath(cfg.AppDir)
+	// Append the network type to the app directory so it is "namespaced"
+	// per network.
+	// All data is specific to a network, so namespacing the data directory
+	// means each individual piece of serialized data does not have to
+	// worry about changing names per network and such.
+	cfg.AppDir = filepath.Join(cfg.AppDir, cfg.NetParams().Name)
+
+	// Logs directory is usually under the home directory, unless otherwise specified
+	if cfg.LogDir == "" {
+		cfg.LogDir = filepath.Join(cfg.AppDir, defaultLogDirname)
+	}
+	cfg.LogDir = cleanAndExpandPath(cfg.LogDir)
+
+	// Special show command to list supported subsystems and exit.
+	if cfg.LogLevel == "show" {
+		fmt.Println("Supported subsystems", kaspaLogger.SupportedSubsystems())
+		os.Exit(0)
+	}
+
+	// Initialize log rotation. After log rotation has been initialized, the
+	// logger variables may be used.
+	logging.InitLog(filepath.Join(cfg.LogDir, defaultLogFilename), filepath.Join(cfg.LogDir, defaultErrLogFilename))
+
+	// Parse, validate, and set debug log level(s).
+	if err := kaspaLogger.ParseAndSetLogLevels(cfg.LogLevel); err != nil {
+		err := errors.Errorf("%s: %s", funcName, err.Error())
+		fmt.Fprintln(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, usageMessage)
+		return nil, err
+	}
+
+	return cfg, nil
 }

--- a/processing/infrastructure/config/config.go
+++ b/processing/infrastructure/config/config.go
@@ -35,7 +35,8 @@ type Flags struct {
 	ConnectPeers             []string `long:"connect" description:"Connect only to the specified peers at startup"`
 	DNSSeed                  string   `long:"dnsseed" description:"Override DNS seeds with specified hostname (Only 1 hostname allowed)"`
 	GRPCSeed                 string   `long:"grpcseed" description:"Hostname of gRPC server for seeding peers"`
-	ClearDB                  bool     `long:"clear-db" description:"Clear the postgres database and resync from scratch"`
+	Resync                   bool     `long:"resync" description:"Force to resync all available node blocks with the PostgrSQL database -- Use if some recently added blocks have missing parents"`
+	ClearDB                  bool     `long:"clear-db" description:"Clear the PostgrSQL database and sync from scratch"`
 	LogLevel                 string   `short:"d" long:"loglevel" description:"Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the log level for individual subsystems -- Use show to list available subsystems"`
 	kaspaConfigPackage.NetworkFlags
 }

--- a/processing/infrastructure/database/database.go
+++ b/processing/infrastructure/database/database.go
@@ -15,11 +15,10 @@ const (
 
 var (
 	log = logging.Logger()
-
-	databaseDirectory = filepath.Join(config.HomeDir, databaseDirectoryName)
 )
 
-func Open() (database.Database, error) {
+func Open(config *config.Config) (database.Database, error) {
+	databaseDirectory := filepath.Join(config.AppDir, databaseDirectoryName)
 	log.Infof("Loading database from '%s'", databaseDirectory)
 	return ldb.NewLevelDB(databaseDirectory, levelDBCacheSizeMiB)
 }

--- a/processing/infrastructure/logging/logging.go
+++ b/processing/infrastructure/logging/logging.go
@@ -2,24 +2,16 @@ package logging
 
 import (
 	"fmt"
-	"github.com/kaspa-live/kaspa-graph-inspector/processing/infrastructure/config"
 	"github.com/kaspanet/kaspad/infrastructure/logger"
 	"os"
-	"path/filepath"
-)
-
-const (
-	logFileName      = "kaspa-graph-inspector-processing.log"
-	errorLogFileName = "kaspa-graph-inspector-processing_errors.log"
 )
 
 var (
 	log = logger.RegisterSubSystem("KAGI")
 )
 
-func init() {
-	logFile := filepath.Join(config.HomeDir, logFileName)
-	errorLogFile := filepath.Join(config.HomeDir, errorLogFileName)
+// InitLog attaches log file and error log file to the backend log.
+func InitLog(logFile, errLogFile string) {
 
 	// 280 MB (MB=1000^2 bytes)
 	err := logger.BackendLog.AddLogFileWithCustomRotator(logFile, logger.LevelTrace, 1000*280, 64)
@@ -27,9 +19,9 @@ func init() {
 		_, _ = fmt.Fprintf(os.Stderr, "Error adding log file %s as log rotator for level %s: %s", logFile, logger.LevelTrace, err)
 		os.Exit(1)
 	}
-	err = logger.BackendLog.AddLogFile(errorLogFile, logger.LevelWarn)
+	err = logger.BackendLog.AddLogFile(errLogFile, logger.LevelWarn)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "Error adding log file %s as log rotator for level %s: %s", errorLogFile, logger.LevelWarn, err)
+		_, _ = fmt.Fprintf(os.Stderr, "Error adding log file %s as log rotator for level %s: %s", errLogFile, logger.LevelWarn, err)
 		os.Exit(1)
 	}
 	logger.InitLogStdout(logger.LevelInfo)

--- a/processing/kaspad/kaspad.go
+++ b/processing/kaspad/kaspad.go
@@ -3,7 +3,7 @@ package kaspad
 import (
 	configPackage "github.com/kaspa-live/kaspa-graph-inspector/processing/infrastructure/config"
 	"github.com/kaspa-live/kaspa-graph-inspector/processing/infrastructure/database"
-	"github.com/kaspa-live/kaspa-graph-inspector/processing/infrastructure/logging"
+	//"github.com/kaspa-live/kaspa-graph-inspector/processing/infrastructure/logging"
 	domainPackage "github.com/kaspa-live/kaspa-graph-inspector/processing/kaspad/domain"
 	consensusPackage "github.com/kaspa-live/kaspa-graph-inspector/processing/kaspad/domain/consensus"
 	"github.com/kaspanet/kaspad/app/protocol"
@@ -33,9 +33,9 @@ func New(config *configPackage.Config) (*Kaspad, error) {
 	kaspadConfig.NetworkFlags = config.NetworkFlags
 	kaspadConfig.Lookup = net.LookupIP
 
-	logging.UpdateLogLevels()
+	//logging.UpdateLogLevels()
 
-	databaseContext, err := database.Open()
+	databaseContext, err := database.Open(config)
 	if err != nil {
 		return nil, err
 	}

--- a/processing/main.go
+++ b/processing/main.go
@@ -1,20 +1,22 @@
 package main
 
 import (
+	"os"
+	"time"
+
 	databasePackage "github.com/kaspa-live/kaspa-graph-inspector/processing/database"
 	configPackage "github.com/kaspa-live/kaspa-graph-inspector/processing/infrastructure/config"
 	"github.com/kaspa-live/kaspa-graph-inspector/processing/infrastructure/logging"
 	kaspadPackage "github.com/kaspa-live/kaspa-graph-inspector/processing/kaspad"
 	processingPackage "github.com/kaspa-live/kaspa-graph-inspector/processing/processing"
 	"github.com/kaspanet/kaspad/domain/consensus/model/externalapi"
-	"os"
-	"time"
+	"github.com/kaspanet/kaspad/infrastructure/logger"
 )
 
 var log = logging.Logger()
 
 func main() {
-	config, err := configPackage.Parse()
+	config, err := configPackage.LoadConfig()
 	if err != nil {
 		logErrorAndExit("Could not parse command line arguments.\n%s", err)
 	}
@@ -61,6 +63,12 @@ func main() {
 }
 
 func logErrorAndExit(errorLog string, logParameters ...interface{}) {
+	// If LoadConfig failed, the logger backend may not have been run yet
+	if !log.Backend().IsRunning() {
+		logger.InitLogStdout(logger.LevelInfo)
+		logging.UpdateLogLevels()
+	}
+
 	log.Errorf(errorLog, logParameters...)
 
 	exitHandlerDone := make(chan struct{})

--- a/processing/processing/batch/batch.go
+++ b/processing/processing/batch/batch.go
@@ -1,0 +1,135 @@
+package batch
+
+import (
+	"github.com/go-pg/pg/v10"
+	databasePackage "github.com/kaspa-live/kaspa-graph-inspector/processing/database"
+	kaspadPackage "github.com/kaspa-live/kaspa-graph-inspector/processing/kaspad"
+	"github.com/kaspanet/kaspad/domain/consensus/database"
+	"github.com/kaspanet/kaspad/domain/consensus/model/externalapi"
+	"github.com/pkg/errors"
+)
+
+type Batch struct {
+	database      *databasePackage.Database
+	kaspad        *kaspadPackage.Kaspad
+	blocks        []*BlockAndHash
+	hashes        map[externalapi.DomainHash]*BlockAndHash
+	prunningBlock *externalapi.DomainBlock
+}
+
+type Block externalapi.DomainBlock
+
+type BlockAndHash struct {
+	*externalapi.DomainBlock
+	hash *externalapi.DomainHash
+}
+
+func New(database *databasePackage.Database, kaspad *kaspadPackage.Kaspad, prunningBlock *externalapi.DomainBlock) *Batch {
+	batch := &Batch{
+		database:      database,
+		kaspad:        kaspad,
+		blocks:        make([]*BlockAndHash, 0),
+		hashes:        make(map[externalapi.DomainHash]*BlockAndHash),
+		prunningBlock: prunningBlock,
+	}
+	return batch
+}
+
+// InScope returns true if `block` has a greater DAA score than the pruning block
+// or if no pruning block is defined
+func (b *Batch) InScope(block *externalapi.DomainBlock) bool {
+	return b.prunningBlock == nil || b.prunningBlock.Header.DAAScore() <= block.Header.DAAScore()
+}
+
+// Add adds a pair `hash` and its matching `block` to the batch.
+// Avoid duplicates and ignore blocks not in scope
+func (b *Batch) Add(hash *externalapi.DomainHash, block *externalapi.DomainBlock) {
+	if !b.Has(hash) && b.InScope(block) {
+		ba := &BlockAndHash{
+			DomainBlock: block,
+			hash:        hash,
+		}
+		b.blocks = append(b.blocks, ba)
+		b.hashes[*hash] = ba
+	}
+}
+
+// Has returns true if `hash` exists in the batch
+func (b *Batch) Has(hash *externalapi.DomainHash) bool {
+	_, ok := b.hashes[*hash]
+	return ok
+}
+
+// Get returns the block identified by `hash`.
+// Returns false if the hash is not found
+func (b *Batch) Get(hash *externalapi.DomainHash) (*externalapi.DomainBlock, bool) {
+	value, ok := b.hashes[*hash]
+	if !ok {
+		return nil, false
+	}
+	return value.DomainBlock, true
+}
+
+func (b *Batch) Empty() bool {
+	return len(b.blocks) == 0
+}
+
+// Pop returns the latest hash and block added and removes the pair from the batch.
+// Returns false if the batch is empty
+func (b *Batch) Pop() (*externalapi.DomainHash, *externalapi.DomainBlock, bool) {
+	cnt := len(b.blocks)
+	if cnt == 0 {
+		return nil, nil, false
+	}
+	blockAddress := b.blocks[cnt-1]
+
+	// remove blockAddress from batch
+	if cnt > 1 {
+		b.blocks = b.blocks[:cnt-1]
+	} else {
+		b.blocks = make([]*BlockAndHash, 0)
+	}
+	delete(b.hashes, *blockAddress.hash)
+
+	return blockAddress.hash, blockAddress.DomainBlock, true
+}
+
+// CollectBlockAndDependencies adds `block` and all its missing direct and
+// indirect dependencies
+func (b *Batch) CollectBlockAndDependencies(databaseTransaction *pg.Tx, hash *externalapi.DomainHash, block *externalapi.DomainBlock) error {
+	b.Add(hash, block)
+	for i := 0; i < len(b.blocks); i++ {
+		item := b.blocks[i]
+		err := b.CollectDirectDependencies(databaseTransaction, item.hash, item.DomainBlock)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// CollectDirectDependencies adds the missing direct parents of `block`
+func (b *Batch) CollectDirectDependencies(databaseTransaction *pg.Tx, hash *externalapi.DomainHash, block *externalapi.DomainBlock) error {
+	parentHashes := block.Header.DirectParents()
+	for _, parentHash := range parentHashes {
+		parentExists, err := b.database.DoesBlockExist(databaseTransaction, parentHash)
+		if err != nil {
+			// enhanced error description
+			return errors.Wrapf(err, "Could not check if parent %s for block %s does exist in database", parentHash, hash)
+		}
+		if !parentExists {
+			parentBlock, err := b.kaspad.Domain().Consensus().GetBlockEvenIfHeaderOnly(parentHash)
+			if err != nil {
+				// We ignore the `block not found` kaspad error.
+				// In this case the parent is out the node scope so we have no way
+				// to include it in the batch
+				if !errors.Is(err, database.ErrNotFound) {
+					return err
+				}
+			} else {
+				b.Add(parentHash, parentBlock)
+			}
+		}
+	}
+	return nil
+}

--- a/processing/processing/processing.go
+++ b/processing/processing/processing.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kaspa-live/kaspa-graph-inspector/processing/infrastructure/logging"
 	"github.com/kaspa-live/kaspa-graph-inspector/processing/infrastructure/tools"
 	kaspadPackage "github.com/kaspa-live/kaspa-graph-inspector/processing/kaspad"
+	"github.com/kaspa-live/kaspa-graph-inspector/processing/processing/batch"
 	"github.com/kaspanet/kaspad/domain/consensus/model/externalapi"
 	"github.com/kaspanet/kaspad/domain/consensus/utils/consensushashing"
 	"github.com/pkg/errors"
@@ -55,6 +56,11 @@ func (p *Processing) ResyncDatabase() error {
 			return err
 		}
 
+		pruningPointBlock, err := p.kaspad.Domain().Consensus().GetBlock(pruningPointHash)
+		if err != nil {
+			return err
+		}
+
 		hasPruningBlock, err := p.database.DoesBlockExist(databaseTransaction, pruningPointHash)
 		if err != nil {
 			return err
@@ -84,10 +90,6 @@ func (p *Processing) ResyncDatabase() error {
 			}
 			log.Infof("Database cleared")
 
-			pruningPointBlock, err := p.kaspad.Domain().Consensus().GetBlock(pruningPointHash)
-			if err != nil {
-				return err
-			}
 			pruningPointDatabaseBlock := &model.Block{
 				BlockHash:                      pruningPointHash.String(),
 				Timestamp:                      pruningPointBlock.Header.TimeInMilliseconds(),
@@ -138,7 +140,11 @@ func (p *Processing) ResyncDatabase() error {
 			if err != nil {
 				return err
 			}
-			if pruningPointDatabaseBlock.DAAScore == 0 {
+			noDAAScoreCount, err := p.database.BlockCountAtDAAScore(databaseTransaction, 0)
+			if err != nil {
+				return err
+			}
+			if pruningPointDatabaseBlock.DAAScore == 0 && noDAAScoreCount > uint32(p.config.NetParams().K) {
 				log.Infof("Updating DAA score of %d blocks in the database", len(hashesBetweenPruningPointAndHeadersSelectedTip))
 				blockIDsToDAAScores, err := p.getBlocksDAAScores(databaseTransaction, hashesBetweenPruningPointAndHeadersSelectedTip)
 				log.Infof("DAA scores of %d blocks collected", len(blockIDsToDAAScores))
@@ -154,13 +160,15 @@ func (p *Processing) ResyncDatabase() error {
 			// End of special case
 
 			log.Infof("Syncing %d blocks with the database", len(hashesBetweenPruningPointAndHeadersSelectedTip))
-			startIndex, err = p.database.FindLatestStoredBlockIndex(databaseTransaction, hashesBetweenPruningPointAndHeadersSelectedTip)
-			if err != nil {
-				return err
+			if !p.config.Resync {
+				startIndex, err = p.database.FindLatestStoredBlockIndex(databaseTransaction, hashesBetweenPruningPointAndHeadersSelectedTip)
+				if err != nil {
+					return err
+				}
+				log.Infof("First %d blocks already exist in the database", startIndex)
+				// We start from an earlier point (~ 10 minutes) to make sure we didn't miss any mutation
+				startIndex = tools.Max(startIndex-600, 0)
 			}
-			log.Infof("First %d blocks already exist in the database", startIndex)
-			// We start from an earlier point (~ 5 minutes) to make sure we didn't miss any mutation
-			startIndex = tools.Max(startIndex-600, 0)
 		} else {
 			log.Infof("Adding %d blocks to the database", len(hashesBetweenPruningPointAndHeadersSelectedTip))
 		}
@@ -172,7 +180,7 @@ func (p *Processing) ResyncDatabase() error {
 			if err != nil {
 				return err
 			}
-			err = p.processBlock(databaseTransaction, block, nil)
+			err = p.processBlockAndDependencies(databaseTransaction, blockHash, block, pruningPointBlock, nil)
 			if err != nil {
 				return err
 			}
@@ -223,7 +231,7 @@ func (p *Processing) resyncVirtualSelectedParentChain(databaseTransaction *pg.Tx
 		blockInsertionResult := &externalapi.VirtualChangeSet{
 			VirtualSelectedParentChainChanges: virtualSelectedParentChain,
 		}
-		err = p.processBlock(databaseTransaction, virtualSelectedParentBlock, blockInsertionResult)
+		err = p.processBlockAndDependencies(databaseTransaction, virtualSelectedParentHash, virtualSelectedParentBlock, nil, blockInsertionResult)
 		if err != nil {
 			return err
 		}
@@ -239,8 +247,37 @@ func (p *Processing) ProcessBlock(block *externalapi.DomainBlock,
 	defer p.Unlock()
 
 	return p.database.RunInTransaction(func(databaseTransaction *pg.Tx) error {
-		return p.processBlock(databaseTransaction, block, blockInsertionResult)
+		return p.processBlockAndDependencies(databaseTransaction, consensushashing.BlockHash(block), block, nil, blockInsertionResult)
 	})
+}
+
+// processBlockAndDependencies processes `block` and all its missing dependencies
+func (p *Processing) processBlockAndDependencies(databaseTransaction *pg.Tx, hash *externalapi.DomainHash,
+	block, pruningBlock *externalapi.DomainBlock, blockInsertionResult *externalapi.VirtualChangeSet) error {
+
+	batch := batch.New(p.database, p.kaspad, pruningBlock)
+	err := batch.CollectBlockAndDependencies(databaseTransaction, hash, block)
+	if err != nil {
+		return err
+	}
+	for {
+		_, block, ok := batch.Pop()
+		if !ok {
+			break
+		}
+		// The VirtualChangeSet `blockInsertionResult` only applies to
+		// `block`, not to its dependencies
+		var virtualChangeSet *externalapi.VirtualChangeSet
+		if batch.Empty() {
+			virtualChangeSet = blockInsertionResult
+		}
+
+		err = p.processBlock(databaseTransaction, block, virtualChangeSet)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (p *Processing) processBlock(databaseTransaction *pg.Tx, block *externalapi.DomainBlock,
@@ -372,7 +409,7 @@ func (p *Processing) processBlock(databaseTransaction *pg.Tx, block *externalapi
 	blockID, err := p.database.BlockIDByHash(databaseTransaction, blockHash)
 	if err != nil {
 		// enhanced error description
-		return errors.Wrapf(err, "Could not get id for edged block %s", blockHash)
+		return errors.Wrapf(err, "Could not get id for block %s", blockHash)
 	}
 	err = p.database.UpdateBlockSelectedParent(databaseTransaction, blockID, selectedParentID)
 	if err != nil {
@@ -388,6 +425,7 @@ func (p *Processing) processBlock(databaseTransaction *pg.Tx, block *externalapi
 		// Let's ignore this error temporarily and just report it in the log
 		// This occures sometimes when the app was fresly started, at the end or just after ResyncDatabase
 		// The actual conditions and the way to solve this has to be determined yet.
+		// Update 2022-04-22: processBlockAndDependencies should solve the issue
 		log.Errorf("Could not get ids of merge set reds for block %s: %s", blockHash, blockGHOSTDAGData.MergeSetReds())
 	}
 	mergeSetBlueIDs, err := p.database.BlockIDsByHashes(databaseTransaction, blockGHOSTDAGData.MergeSetBlues())
@@ -398,6 +436,7 @@ func (p *Processing) processBlock(databaseTransaction *pg.Tx, block *externalapi
 		// Let's ignore this error temporarily and just report it in the log
 		// This occures sometimes when the app was fresly started, at the end or just after ResyncDatabase
 		// The actual conditions and the way to solve this has to be determined yet.
+		// Update 2022-04-22: processBlockAndDependencies should solve the issue
 		log.Errorf("Could not get ids of merge set blues for block %s: %s", blockHash, blockGHOSTDAGData.MergeSetBlues())
 	}
 	err = p.database.UpdateBlockMergeSet(databaseTransaction, blockID, mergeSetRedIDs, mergeSetBlueIDs)

--- a/processing/processing/processing.go
+++ b/processing/processing/processing.go
@@ -287,7 +287,7 @@ func (p *Processing) processBlock(databaseTransaction *pg.Tx, block *externalapi
 		heightGroupSize, err := p.database.HeightGroupSize(databaseTransaction, blockHeight)
 		if err != nil {
 			// enhanced error description
-			return errors.Wrapf(err, "Could not resolve group size for highest parent height %s for block %s", blockHeight, blockHash)
+			return errors.Wrapf(err, "Could not resolve group size for highest parent height %d for block %s", blockHeight, blockHash)
 		}
 		blockHeightGroupIndex := heightGroupSize
 
@@ -321,19 +321,19 @@ func (p *Processing) processBlock(databaseTransaction *pg.Tx, block *externalapi
 		err = p.database.InsertOrUpdateHeightGroup(databaseTransaction, heightGroup)
 		if err != nil {
 			// enhanced error description
-			return errors.Wrapf(err, "Could not insert or update height group %s for block %s", blockHeight, blockHash)
+			return errors.Wrapf(err, "Could not insert or update height group %d for block %s", blockHeight, blockHash)
 		}
 
 		for _, parentID := range parentIDs {
 			parentHeight, err := p.database.BlockHeight(databaseTransaction, parentID)
 			if err != nil {
 				// enhanced error description
-				return errors.Wrapf(err, "Could not get block height of parent id %s for block %s", parentID, blockHash)
+				return errors.Wrapf(err, "Could not get block height of parent id %d for block %s", parentID, blockHash)
 			}
 			parentHeightGroupIndex, err := p.database.BlockHeightGroupIndex(databaseTransaction, parentID)
 			if err != nil {
 				// enhanced error description
-				return errors.Wrapf(err, "Could not get height group index of parent id %s for block %s", parentID, blockHash)
+				return errors.Wrapf(err, "Could not get height group index of parent id %d for block %s", parentID, blockHash)
 			}
 			edge := &model.Edge{
 				FromBlockID:          blockID,
@@ -346,7 +346,7 @@ func (p *Processing) processBlock(databaseTransaction *pg.Tx, block *externalapi
 			err = p.database.InsertEdge(databaseTransaction, edge)
 			if err != nil {
 				// enhanced error description
-				return errors.Wrapf(err, "Could not insert edge from block %s to parent id %s", blockHash, parentID)
+				return errors.Wrapf(err, "Could not insert edge from block %s to parent id %d", blockHash, parentID)
 			}
 		}
 	}

--- a/web/src/components/BlockInformationPanel.css
+++ b/web/src/components/BlockInformationPanel.css
@@ -62,8 +62,16 @@
     align-self: flex-start;
 }
 
+.block-information-panel .block-daa-score {
+    align-self: flex-start;
+}
+
 .block-information-panel .selected-parent-hash {
-    font-weight: bold;
+  font-weight: bold;
+}
+
+.block-information-panel .selected-child-hash {
+  font-weight: bold;
 }
 
 .information-tooltip {

--- a/web/src/components/BlockInformationPanel.tsx
+++ b/web/src/components/BlockInformationPanel.tsx
@@ -38,7 +38,7 @@ const BlockInformationPanel = ({blockInformation, onClose, onSelectHash}:
     const blockParentsTooltip = <div className="information-tooltip">
         <p>Every block in the block DAG (aside from the genesis) has one or more <b>parents.</b> A <b>parent</b> is
             simply the hash of another block that had been added to the DAG at a prior time.</p>
-        <p>Here, we represent each parent with an arrow. Note that all arrows point from right to left—from child to
+        <p>Here, we represent each parent with an arrow. Note that all arrows point from right to left — from child to
             parent. Moving towards the left in the graph reveals increasingly older generations of blocks until we reach
             the leftmost, and oldest, block. That's the origin of the DAG, or the genesis.</p>
         <p>A block's <b>selected parent</b> is the parent that has the most accumulated proof-of-work.</p>
@@ -76,12 +76,21 @@ const BlockInformationPanel = ({blockInformation, onClose, onSelectHash}:
     </div>;
 
     const blockDAAScoreTooltip = <div className="information-tooltip">
-    <p>Every block in the DAG has a DAA Score.</p>
-    <p>The DAA Score is related to the number of honest blocks ever added to the DAG. Since blocks are created at a rate
-       of one per second, the score is also a metric of the elapsed time since network launch.</p>
+        <p>Every block in the DAG has a DAA Score.</p>
+        <p>The DAA Score is related to the number of honest blocks ever added to the DAG. Since blocks are created at a
+            rate of one per second, the score is a metric of the elapsed time since network launch.</p>
     </div>;
 
-const parentElements = [];
+    const blockChildrenTooltip = <div className="information-tooltip">
+        <p>Every block in the block DAG (aside from the blocks forming the tips) has one or more <b>children.</b> A <b>child</b> is
+           simply the hash of another block that has been added to the DAG at a later time and that has the block
+            hash in its parents.</p>
+        <p>Here, we represent each child with an arrow. Note that all arrows point from right to left — from child to
+            parent. Moving towards the right in the graph reveals increasingly younger generations of blocks until we
+            reach the rightmosts, and youngest, blocks. That's the tips of the DAG.</p>
+    </div>;
+
+    const parentElements = [];
     if (blockInformation.isInformationComplete) {
         for (let parentHash of blockInformation.parentHashes) {
             const className = blockInformation.selectedParentHash === parentHash ? "selected-parent-hash" : "";
@@ -101,6 +110,14 @@ const parentElements = [];
         }
     }
 
+    const childElements = [];
+    if (blockInformation.isInformationComplete) {
+        for (let childHash of blockInformation.childHashes) {
+            const className = blockInformation.selectedChildHash === childHash ? "selected-child-hash" : "";
+            childElements.push(<BlockInformationPanelHash hash={childHash} className={className} onSelect={onSelectHash}/>)
+        }
+    }
+
     return <Paper elevation={4}>
         <div className="block-information-panel">
             <div className="block-information-header">
@@ -116,13 +133,13 @@ const parentElements = [];
                     {!blockInformation.isInformationComplete
                         ? undefined
                         : <List>
-                            <BlockInformationPanelListItem label="Block Hash" tooltip={blockHashTooltip}>
+                            <BlockInformationPanelListItem itemKey="block-hash" label="Block Hash" tooltip={blockHashTooltip}>
                                 <BlockInformationPanelHash hash={blockInformation.block.blockHash} onSelect={onSelectHash}/>
                             </BlockInformationPanelListItem>
 
                             <Divider className="block-information-divider"/>
 
-                            <BlockInformationPanelListItem label="Block Parents" tooltip={blockParentsTooltip}>
+                            <BlockInformationPanelListItem itemKey="block-parents" label="Block Parents" tooltip={blockParentsTooltip}>
                                 {parentElements.length === 0
                                     ?
                                     <Typography className="block-information-panel-hash"
@@ -133,7 +150,7 @@ const parentElements = [];
 
                             <Divider className="block-information-divider"/>
 
-                            <BlockInformationPanelListItem label="Block Merge Set" tooltip={blockMergeSetTooltip}>
+                            <BlockInformationPanelListItem itemKey="block-merge-set" label="Block Merge Set" tooltip={blockMergeSetTooltip}>
                                 {mergeSetHashElements.length === 0
                                     ?
                                     <Typography className="block-information-panel-hash"
@@ -144,7 +161,18 @@ const parentElements = [];
 
                             <Divider className="block-information-divider"/>
 
-                            <BlockInformationPanelListItem label="Is Block In VSPC"
+                            <BlockInformationPanelListItem itemKey="block-children" label="Block Children" tooltip={blockChildrenTooltip}>
+                                {childElements.length === 0
+                                    ?
+                                    <Typography className="block-information-panel-hash"
+                                                variant="h6">None</Typography>
+                                    : childElements
+                                }
+                            </BlockInformationPanelListItem>
+
+                            <Divider className="block-information-divider"/>
+
+                            <BlockInformationPanelListItem itemKey="is-bloc-vspc" label="Is Block In VSPC"
                                                            tooltip={isBlockInVirtualSelectedParentChainTooltip}>
                                 <Typography className="is-block-in-virtual-selected-parent-chain" variant="h6">
                                     {blockInformation.block.isInVirtualSelectedParentChain ? "Yes" : "No"}
@@ -153,7 +181,7 @@ const parentElements = [];
 
                             <Divider className="block-information-divider"/>
 
-                            <BlockInformationPanelListItem label="Block Color" tooltip={blockColorTooltip}>
+                            <BlockInformationPanelListItem itemKey="block-color" label="Block Color" tooltip={blockColorTooltip}>
                                 <Typography className={`block-color ${blockColorClass}`} variant="h6">
                                     {blockColorText}
                                 </Typography>
@@ -161,8 +189,8 @@ const parentElements = [];
 
                             <Divider className="block-information-divider"/>
 
-                            <BlockInformationPanelListItem label="DAA Score" tooltip={blockDAAScoreTooltip}>
-                                <Typography className="block-information-panel-hash" variant="h6">
+                            <BlockInformationPanelListItem itemKey="block-daa-score" label="Block DAA Score" tooltip={blockDAAScoreTooltip}>
+                                <Typography className="block-daa-score" variant="h6">
                                     {blockDAAScore}
                                 </Typography>
                             </BlockInformationPanelListItem>

--- a/web/src/components/BlockInformationPanelListItem.tsx
+++ b/web/src/components/BlockInformationPanelListItem.tsx
@@ -4,10 +4,10 @@ import {ReactFragment, ReactNode} from "react";
 import InfoOutlinedIcon from '@material-ui/icons/InfoOutlined';
 import BlockInformationPanelTooltip from "./BlockInformationPanelTooltip";
 
-const BlockInformationPanelListItem = ({children, label, tooltip}:
-                                           { children: ReactNode, label: string, tooltip: ReactFragment }) => {
+const BlockInformationPanelListItem = ({itemKey, children, label, tooltip}:
+                                           { itemKey: string, children: ReactNode, label: string, tooltip: ReactFragment }) => {
 
-    return <ListItem className="block-information-panel-list-item" disableGutters>
+    return <ListItem key={itemKey} className="block-information-panel-list-item" disableGutters>
         <div className="header">
             <Typography className="label" variant="h6">
                 {label}

--- a/web/src/dag/EdgeSprite.ts
+++ b/web/src/dag/EdgeSprite.ts
@@ -18,13 +18,15 @@ class EdgeGraphicsDefinition {
 }
 
 export default class EdgeSprite extends PIXI.Container {
-    private readonly normalDefinition = new EdgeGraphicsDefinition(0xaaaaaa, 2, 4);
-    private readonly inVirtualSelectedParentChainDefinition = new EdgeGraphicsDefinition(0xb4cfed, 4, 6);
-    private readonly highlightedParentDefinition = new EdgeGraphicsDefinition(0x6be39f, 4, 6);
-    private readonly highlightedChildDefinition = new EdgeGraphicsDefinition(0x6be39f, 4, 6);
-    private readonly highlightedSelectedParentDefinition = new EdgeGraphicsDefinition(0x4de3bb, 6, 8);
-    private readonly highlightedParentInVirtualSelectedParentChainDefinition = new EdgeGraphicsDefinition(0x7ce0e6, 6, 8);
-    private readonly highlightedChildInVirtualSelectedParentChainDefinition = new EdgeGraphicsDefinition(0x7ce0e6, 6, 8);
+    private static readonly normalDefinition = new EdgeGraphicsDefinition(0xaaaaaa, 2, 4);
+    private static readonly inVirtualSelectedParentChainDefinition = new EdgeGraphicsDefinition(0xb4cfed, 4, 6);
+    private static readonly highlightedParentDefinition = new EdgeGraphicsDefinition(0x6be39f, 4, 6);
+    private static readonly highlightedChildDefinition = new EdgeGraphicsDefinition(0x6be39f, 4, 6);
+    private static readonly highlightedSelectedParentDefinition = new EdgeGraphicsDefinition(0x4de3bb, 6, 8);
+    private static readonly highlightedParentInVirtualSelectedParentChainDefinition = new EdgeGraphicsDefinition(0x7ce0e6, 6, 8);
+    private static readonly highlightedChildInVirtualSelectedParentChainDefinition = new EdgeGraphicsDefinition(0x7ce0e6, 6, 8);
+
+    private static readonly definitionMap: { [definitionKey: string]: EdgeGraphicsDefinition } = EdgeSprite.initializeDefinitionMap();
 
     private readonly application: PIXI.Application;
     private readonly fromBlockId: number;
@@ -41,7 +43,6 @@ export default class EdgeSprite extends PIXI.Container {
     private isHighlightedChild: boolean = false;
     private isSelectedParent: boolean = false;
 
-    private definitionMap: { [definitionKey: string]: EdgeGraphicsDefinition } = {};
     private graphicsMap: { [definitionKey: string]: PIXI.Graphics } = {};
 
     constructor(application: PIXI.Application, fromBlockId: number, toBlockId: number) {
@@ -51,18 +52,22 @@ export default class EdgeSprite extends PIXI.Container {
         this.fromBlockId = fromBlockId;
         this.toBlockId = toBlockId;
 
-        this.definitionMap[this.normalDefinition.key()] = this.normalDefinition;
-        this.definitionMap[this.inVirtualSelectedParentChainDefinition.key()] = this.inVirtualSelectedParentChainDefinition;
-        this.definitionMap[this.highlightedParentDefinition.key()] = this.highlightedParentDefinition;
-        this.definitionMap[this.highlightedChildDefinition.key()] = this.highlightedChildDefinition;
-        this.definitionMap[this.highlightedSelectedParentDefinition.key()] = this.highlightedSelectedParentDefinition;
-        this.definitionMap[this.highlightedParentInVirtualSelectedParentChainDefinition.key()] = this.highlightedParentInVirtualSelectedParentChainDefinition;
-        this.definitionMap[this.highlightedChildInVirtualSelectedParentChainDefinition.key()] = this.highlightedChildInVirtualSelectedParentChainDefinition;
-
-        for (let definitionKey in this.definitionMap) {
+        for (let definitionKey in EdgeSprite.definitionMap) {
             this.graphicsMap[definitionKey] = this.addNewGraphics();
         }
-        this.graphicsMap[this.normalDefinition.key()].alpha = 1.0;
+        this.graphicsMap[EdgeSprite.normalDefinition.key()].alpha = 1.0;
+    }
+
+    private static initializeDefinitionMap(): Record<string, EdgeGraphicsDefinition> {
+        let definitionMap: { [definitionKey: string]: EdgeGraphicsDefinition } = {};
+        definitionMap[EdgeSprite.normalDefinition.key()] = EdgeSprite.normalDefinition;
+        definitionMap[EdgeSprite.inVirtualSelectedParentChainDefinition.key()] = EdgeSprite.inVirtualSelectedParentChainDefinition;
+        definitionMap[EdgeSprite.highlightedParentDefinition.key()] = EdgeSprite.highlightedParentDefinition;
+        definitionMap[EdgeSprite.highlightedChildDefinition.key()] = EdgeSprite.highlightedChildDefinition;
+        definitionMap[EdgeSprite.highlightedSelectedParentDefinition.key()] = EdgeSprite.highlightedSelectedParentDefinition;
+        definitionMap[EdgeSprite.highlightedParentInVirtualSelectedParentChainDefinition.key()] = EdgeSprite.highlightedParentInVirtualSelectedParentChainDefinition;
+        definitionMap[EdgeSprite.highlightedChildInVirtualSelectedParentChainDefinition.key()] = EdgeSprite.highlightedChildInVirtualSelectedParentChainDefinition;
+        return definitionMap;
     }
 
     private addNewGraphics = (): PIXI.Graphics => {
@@ -83,8 +88,8 @@ export default class EdgeSprite extends PIXI.Container {
             this.blockBoundsVectorX = blockBoundsVectorX;
             this.blockBoundsVectorY = blockBoundsVectorY;
 
-            for (let definitionKey in this.definitionMap) {
-                const definition = this.definitionMap[definitionKey];
+            for (let definitionKey in EdgeSprite.definitionMap) {
+                const definition = EdgeSprite.definitionMap[definitionKey];
                 const graphics = this.graphicsMap[definitionKey];
                 this.renderGraphics(graphics, definition);
             }
@@ -181,23 +186,23 @@ export default class EdgeSprite extends PIXI.Container {
         let definition;
         if (this.isInVirtualSelectedParentChain) {
             if (this.isHighlightedParent) {
-                definition = this.highlightedParentInVirtualSelectedParentChainDefinition;
+                definition = EdgeSprite.highlightedParentInVirtualSelectedParentChainDefinition;
             } else if (this.isHighlightedChild) {
-                definition = this.highlightedChildInVirtualSelectedParentChainDefinition;
+                definition = EdgeSprite.highlightedChildInVirtualSelectedParentChainDefinition;
             } else {
-                definition = this.inVirtualSelectedParentChainDefinition;
+                definition = EdgeSprite.inVirtualSelectedParentChainDefinition;
             }
         } else {
             if (this.isHighlightedParent) {
                 if (this.isSelectedParent) {
-                    definition = this.highlightedSelectedParentDefinition;
+                    definition = EdgeSprite.highlightedSelectedParentDefinition;
                 } else {
-                    definition = this.highlightedParentDefinition;
+                    definition = EdgeSprite.highlightedParentDefinition;
                 }
             } else if (this.isHighlightedChild) {
-                definition = this.highlightedChildDefinition;
+                definition = EdgeSprite.highlightedChildDefinition;
             } else {
-                definition = this.normalDefinition;
+                definition = EdgeSprite.normalDefinition;
             }
         }
         this.changeShownGraphics(definition);

--- a/web/src/dag/TimelineContainer.ts
+++ b/web/src/dag/TimelineContainer.ts
@@ -61,6 +61,8 @@ export default class TimelineContainer extends PIXI.Container {
         this.addChild(this.blockContainer);
     }
 
+    gettBlocksAndEdgesAndHeightGroups = (): BlocksAndEdgesAndHeightGroups | null => this.currentBlocksAndEdgesAndHeightGroups;
+
     setBlocksAndEdgesAndHeightGroups = (blocksAndEdgesAndHeightGroups: BlocksAndEdgesAndHeightGroups, targetBlock: Block | null = null) => {
         // Don't bother updating anything if there's nothing to update
         // noinspection JSSuspiciousNameCombination

--- a/web/src/model/BlockInformation.ts
+++ b/web/src/model/BlockInformation.ts
@@ -6,6 +6,8 @@ export type BlockInformation = {
     selectedParentHash: string | null,
     mergeSetRedHashes: string[],
     mergeSetBlueHashes: string[],
+    childHashes: string[],
+    selectedChildHash: string | null,
 
     isInformationComplete: boolean,
 };

--- a/web/src/model/BlocksAndEdgesAndHeightGroups.ts
+++ b/web/src/model/BlocksAndEdgesAndHeightGroups.ts
@@ -76,3 +76,31 @@ export function getDAAScoreGroupHeight(data: BlocksAndEdgesAndHeightGroups, daaS
     }
     return maxHeight;
 }
+
+function getBlockById(data: BlocksAndEdgesAndHeightGroups, blockId: number): Block | null {
+    if (data) {
+        for (let block of data.blocks) {
+            if (block.id === blockId) {
+                return block;
+            }
+        }
+    }
+    return null;
+}
+
+export function getBlockChildIds(data: BlocksAndEdgesAndHeightGroups, block: Block): [number[], number | null] {
+    let children: number[] = [];
+    let selectedChild = null;
+    if (data) { 
+        for (let edge of data.edges) {
+            if (edge.toBlockId === block.id) {
+                children = children.concat(edge.fromBlockId);
+                const childBlock = getBlockById(data, edge.fromBlockId);
+                if (childBlock && childBlock.isInVirtualSelectedParentChain) {
+                    selectedChild = childBlock.id;
+                }
+            }
+        }
+    }
+    return [children, selectedChild];
+}


### PR DESCRIPTION
So far, it has only been possible to interactively navigate the DAG through parents and/or merge set relations. This one-way navigation, moving to ever older blocks down to the genesis, needs a counterpart allowing to move towards the tips of the DAG.

So this PR feature the children hashes among the properties of an inspected block. A click on a child hash moves the inspector to the corresponding block, thus allowing the navigation towards younger blocks and in fine to the tips of the DAG.