### PR TITLE
Enhance the DAG UX

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -2,8 +2,6 @@
   display: flex;
   flex-direction: column;
   max-width: 20vw;
-  text-align: justify;
-  text-justify: inter-character;
 }
 
 .information-tooltip a {
@@ -24,7 +22,7 @@
     width: 20vw;
     height: 100vh;
     transform: translateX(-100%);
-    min-width: 375px;
+    min-width: 320px;
 }
 
 .block-information-open {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,13 +7,6 @@ import Canvas from "./components/Canvas";
 import Sidebar from './components/sidebar/Sidebar';
 import {BlockInformation} from "./model/BlockInformation";
 
-
-// declare module '@mui/styles/defaultTheme' {
-//   // eslint-disable-next-line @typescript-eslint/no-empty-interface
-//   interface DefaultTheme extends Theme {}
-// }
-
-
 const App = () => {
     const [blockInformationState, setBlockInformationState] = useState<BlockInformation | null>(null);
     const [wasBlockSetState, setWasBlockSetState] = useState(false);
@@ -86,17 +79,20 @@ const theme = createTheme({
 
         block: {
             blue: {
-                main: "#b4cfed"
+                main: "#5581AA",
+                dark: "#1f5278",        // https://fffuel.co/cccolor/ - #5581AA - Shade palette 4
+                light: "#95adc8"        // https://fffuel.co/cccolor/ - #5581AA - Tint palette 4
             },
             red: {
-                main: "#ff5972"
+                main: "#B34D50",
+                dark: "#82212a",        // https://fffuel.co/cccolor/ - #B34D50 - Shade palette 4
+                light: "#d48d8b"        // https://fffuel.co/cccolor/ - #B34D50 - Tint palette 4
             },
             gray: {
-                main: "#aaaaaa"
+                main: "#aaaaaa",
             },
         },
-
-    }
+    },
 });
 
 const dag = new Dag();

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -84,15 +84,18 @@ const theme = createTheme({
             paper: "#fff"
         },
 
-        blueBlock: {
-            main: "#b4cfed"
+        block: {
+            blue: {
+                main: "#b4cfed"
+            },
+            red: {
+                main: "#ff5972"
+            },
+            gray: {
+                main: "#aaaaaa"
+            },
         },
-        redBlock: {
-            main: "#ff5972"
-        },
-        newBlock: {
-            main: "#aaaaaa"
-        }
+
     }
 });
 

--- a/web/src/components/base/AnimatedCircle.tsx
+++ b/web/src/components/base/AnimatedCircle.tsx
@@ -13,12 +13,16 @@ const AnimatedCircle = ( {children}: { children: ReactElement } ) => {
       })
     
     return (
+
+        // TODO: We definitely need a touch-aware behaviour here
+        // In the meantime, we reduce the visible effect
+        
         <AnimatedPaper
-            elevation={ x.to( x => Math.round(x * 3 + 2) ) }
-            onMouseEnter={() => toggle(true)}
+            elevation={ x.to( x => Math.round(x * 1 + 2) ) }
+            onMouseOver={() => toggle(true)}
             onMouseLeave={() => toggle(false)}
             style={{
-                scale: x.to({range: [0, 1], output: [1, 1.1] }),
+                scale: x.to({range: [0, 1], output: [1, 1.03] }),
                 borderRadius: "50%",
                 cursor: "pointer",
 

--- a/web/src/components/panel/bloc-information/BlockInformationPanel.tsx
+++ b/web/src/components/panel/bloc-information/BlockInformationPanel.tsx
@@ -7,10 +7,10 @@ import BlockInformationPanelListItem from "./BlockInformationPanelListItem";
 import {katnipAddress} from "../../../addresses";
 import {BlockInformation} from "../../../model/BlockInformation";
 
-const InfoDivider = () => <Divider sx={{backgroundColor: 'primary.contrastText'}}/>
+const InfoDivider = () => <Divider sx={{backgroundColor: 'text.secondary', mt: '4px', mb: '4px'}}/>
 
-const RedBlock = styled('b')(({ theme }) => ({ color: theme.palette.block.red.main }));
-const BlueBlock = styled('b')(({ theme }) => ({ color: theme.palette.block.blue.main }));
+const RedBlock = styled('b')(({ theme }) => ({ color: theme.palette.block.red.light }));
+const BlueBlock = styled('b')(({ theme }) => ({ color: theme.palette.block.blue.light }));
 
 const LeftTypography = styled(Typography)({
     alignSelf: "flex-start",
@@ -134,8 +134,6 @@ const BlockInformationPanel = ({blockInformation, onClose, onClickHash}:
             <Box className="block-information-panel" sx={{
                 height: '100vh',
                 width: '100%',
-                backgroundColor: 'primary.main',
-                color: 'primary.contrastText',
                 display: 'flex',
                 flexDirection: 'column',
             }}>
@@ -144,14 +142,13 @@ const BlockInformationPanel = ({blockInformation, onClose, onClickHash}:
                     flexDirection: 'row',
                     padding: '20px 20px 0',
                 }}>
-                    <Typography variant="h4">
+                    <Typography variant="h5">
                         Block Information
                     </Typography>
                     <IconButton
                         onClick={onClose} 
                         size="large"
                         sx={{
-                            color: 'primary.contrastText',
                             padding: '20px',
                             margin: '-20px -20px auto auto',
                         }}
@@ -186,7 +183,7 @@ const BlockInformationPanel = ({blockInformation, onClose, onClickHash}:
                                 <BlockInformationPanelListItem itemKey="block-parents" label="Block Parents" tooltip={blockParentsTooltip}>
                                     {parentElements.length === 0
                                         ?
-                                        <LeftTypography variant="h6">None</LeftTypography>
+                                        <LeftTypography variant="body1">None</LeftTypography>
                                         : parentElements
                                     }
                                 </BlockInformationPanelListItem>
@@ -196,7 +193,7 @@ const BlockInformationPanel = ({blockInformation, onClose, onClickHash}:
                                 <BlockInformationPanelListItem itemKey="block-merge-set" label="Block Merge Set" tooltip={blockMergeSetTooltip}>
                                     {mergeSetHashElements.length === 0
                                         ?
-                                        <LeftTypography variant="h6">None</LeftTypography>
+                                        <LeftTypography variant="body1">None</LeftTypography>
                                         : mergeSetHashElements
                                     }
                                 </BlockInformationPanelListItem>
@@ -206,7 +203,7 @@ const BlockInformationPanel = ({blockInformation, onClose, onClickHash}:
                                 <BlockInformationPanelListItem itemKey="block-children" label="Block Children" tooltip={blockChildrenTooltip}>
                                     {childElements.length === 0
                                         ?
-                                        <LeftTypography variant="h6">None</LeftTypography>
+                                        <LeftTypography variant="body1">None</LeftTypography>
                                         : childElements
                                     }
                                 </BlockInformationPanelListItem>
@@ -215,7 +212,7 @@ const BlockInformationPanel = ({blockInformation, onClose, onClickHash}:
 
                                 <BlockInformationPanelListItem itemKey="is-bloc-vspc" label="Is Block In VSPC"
                                                                tooltip={isBlockInVirtualSelectedParentChainTooltip}>
-                                    <LeftTypography variant="h6">
+                                    <LeftTypography variant="body1">
                                         {blockInformation.block.isInVirtualSelectedParentChain ? "Yes" : "No"}
                                     </LeftTypography>
                                 </BlockInformationPanelListItem>
@@ -223,15 +220,15 @@ const BlockInformationPanel = ({blockInformation, onClose, onClickHash}:
                                 <InfoDivider/>
 
                                 <BlockInformationPanelListItem itemKey="block-color" label="Block Color" tooltip={blockColorTooltip}>
-                                    <LeftTypography variant="h6" sx={{ color: theme.palette.block[blockColorClass].main }}>
-                                        {blockColorText}
+                                    <LeftTypography variant="body1" sx={{ color: theme.palette.block[blockColorClass].main }}>
+                                        <b>{blockColorText}</b>
                                     </LeftTypography>
                                 </BlockInformationPanelListItem>
 
                                 <InfoDivider/>
 
                                 <BlockInformationPanelListItem itemKey="block-daa-score" label="Block DAA Score" tooltip={blockDAAScoreTooltip}>
-                                    <LeftTypography variant="h6">
+                                    <LeftTypography variant="body1">
                                         {blockDAAScore}
                                     </LeftTypography>
                                 </BlockInformationPanelListItem>
@@ -244,9 +241,11 @@ const BlockInformationPanel = ({blockInformation, onClose, onClickHash}:
                     fontWeight: 'bold',
                     textAlign: 'end',
                     width: '100%',
-                    padding: '0 20px 20px',
+                    padding: '15px 20px 15px',
                 }}>
-                    See more details on <Link href={katnipAddressForBlock} target="_blank" rel="noreferrer" sx={{textDecoration: 'underline', color: 'primary.contrastText'}}>Katnip Block Explorer</Link>
+                    <Typography variant="body2">
+                        More details on <Link href={katnipAddressForBlock} target="_blank" rel="noreferrer" sx={{textDecoration: 'underline', color: 'text.primary', fontWeight: 'bold'}}>Katnip&nbsp;Block&nbsp;Explorer</Link>
+                    </Typography>
                 </Box>
             </Box>
         </Paper>

--- a/web/src/components/panel/bloc-information/BlockInformationPanel.tsx
+++ b/web/src/components/panel/bloc-information/BlockInformationPanel.tsx
@@ -9,8 +9,8 @@ import {BlockInformation} from "../../../model/BlockInformation";
 
 const InfoDivider = () => <Divider sx={{backgroundColor: 'primary.contrastText'}}/>
 
-const RedBlock = styled('b')(({ theme }) => ({ color: theme.palette.redBlock.main }));
-const BlueBlock = styled('b')(({ theme }) => ({ color: theme.palette.blueBlock.main }));
+const RedBlock = styled('b')(({ theme }) => ({ color: theme.palette.block.red.main }));
+const BlueBlock = styled('b')(({ theme }) => ({ color: theme.palette.block.blue.main }));
 
 const LeftTypography = styled(Typography)({
     alignSelf: "flex-start",
@@ -27,13 +27,13 @@ const BlockInformationPanel = ({blockInformation, onClose, onClickHash}:
     const katnipAddressForBlock = `${katnipAddress}/block/${blockInformation.block.blockHash}`;
 
     let blockColorText = "Undecided";
-    let blockColorClass: BlockColor = "newBlock";
+    let blockColorClass: BlockColor = "gray";
     if (blockInformation.block.color === "blue") {
         blockColorText = "Blue";
-        blockColorClass = "blueBlock";
+        blockColorClass = "blue";
     } else if (blockInformation.block.color === "red") {
         blockColorText = "Red";
-        blockColorClass = "redBlock";
+        blockColorClass = "red";
     }
 
     let language = navigator.language || "en-US";
@@ -113,11 +113,11 @@ const BlockInformationPanel = ({blockInformation, onClose, onClickHash}:
     if (blockInformation.isInformationComplete) {
         for (let mergeSetBlueHash of blockInformation.mergeSetBlueHashes) {
             mergeSetHashElements.push(
-                <BlockInformationPanelHash key={mergeSetBlueHash} color="blueBlock" hash={mergeSetBlueHash} onClickHash={onClickHash}/>);
+                <BlockInformationPanelHash key={mergeSetBlueHash} color="blue" hash={mergeSetBlueHash} onClickHash={onClickHash}/>);
         }
         for (let mergeSetRedHash of blockInformation.mergeSetRedHashes) {
             mergeSetHashElements.push(
-                <BlockInformationPanelHash key={mergeSetRedHash} color="redBlock" hash={mergeSetRedHash} onClickHash={onClickHash}/>);
+                <BlockInformationPanelHash key={mergeSetRedHash} color="red" hash={mergeSetRedHash} onClickHash={onClickHash}/>);
         }
     }
 
@@ -223,7 +223,7 @@ const BlockInformationPanel = ({blockInformation, onClose, onClickHash}:
                                 <InfoDivider/>
 
                                 <BlockInformationPanelListItem itemKey="block-color" label="Block Color" tooltip={blockColorTooltip}>
-                                    <LeftTypography variant="h6" sx={{ color: theme.palette[blockColorClass].main }}>
+                                    <LeftTypography variant="h6" sx={{ color: theme.palette.block[blockColorClass].main }}>
                                         {blockColorText}
                                     </LeftTypography>
                                 </BlockInformationPanelListItem>

--- a/web/src/components/panel/bloc-information/BlockInformationPanelHash.tsx
+++ b/web/src/components/panel/bloc-information/BlockInformationPanelHash.tsx
@@ -16,7 +16,7 @@ interface HashTypographyProps extends TypographyProps {
 const HashTypography = styled(
     (
         { selected, color, ...props }: HashTypographyProps
-    ) => (<Typography {...props} variant="h6"/>),
+    ) => (<Typography {...props} variant="body1"/>),
     {
         name: "HashTypography",
         shouldForwardProp: (prop) => prop !== 'selected',
@@ -25,7 +25,7 @@ const HashTypography = styled(
     fontFamily: "monospace",
     textTransform: "uppercase",
     ...(
-        selected && {
+        (selected || color) && {
             fontWeight: "bold",
         }
     ),

--- a/web/src/components/panel/bloc-information/BlockInformationPanelHash.tsx
+++ b/web/src/components/panel/bloc-information/BlockInformationPanelHash.tsx
@@ -31,7 +31,7 @@ const HashTypography = styled(
     ),
     ...(
         color && {
-            color: theme.palette[color].main,
+            color: theme.palette.block[color].main,
         }
     )
 }));

--- a/web/src/components/panel/bloc-information/BlockInformationPanelListItem.tsx
+++ b/web/src/components/panel/bloc-information/BlockInformationPanelListItem.tsx
@@ -25,7 +25,7 @@ const BlockInformationPanelListItem = ({itemKey, children, label, tooltip}:
 
     return <Item key={itemKey} className="block-information-panel-list-item" disableGutters>
         <Header>
-            <Label variant="h6">
+            <Label variant="subtitle1">
                 {label}
             </Label>
             <BlockInformationPanelTooltip title={tooltip}>

--- a/web/src/dag/BlockSprite.ts
+++ b/web/src/dag/BlockSprite.ts
@@ -2,7 +2,7 @@ import * as PIXI from "pixi.js-legacy";
 import { Ease, Tween } from "@createjs/tweenjs";
 import { Block } from "../model/Block";
 import { BlockColorConst, BlockColor } from "../model/BlockColor";
-import { theme } from "./Theme";
+import { HighlightFrame, theme } from "./Theme";
 
 //const blockColors: { [color: string]: number } = {"gray": 0xf5faff, "red": 0xfc606f, "blue": 0xb4cfed};
 //const highlightColors: { [color: string]: number } = {"gray": 0x78869e, "red": 0x9e4949, "blue": 0x49849e};
@@ -113,7 +113,7 @@ export default class BlockSprite extends PIXI.Container {
     }
 
     private buildHighlight = (): PIXI.Graphics => {
-        const blockHighlight = this.hasFocus ? theme.components.block.focus : theme.components.block.highlight;
+        const blockHighlight = this.getHighlightFrame();
         const highlightSize = this.blockSize + blockHighlight.offset;
         const highlightRoundingRadius = theme.components.block.roundingRadius + (blockHighlight.offset / 2);
 
@@ -179,10 +179,11 @@ export default class BlockSprite extends PIXI.Container {
             this.isHighlighted = isHighlighted;
             this.hasFocus = hasFocus;
             this.highlightColor = highlightColor;
+            const blockHighlight = this.getHighlightFrame();
 
             const oldHighlight = this.currentHighlight;
 
-            if (oldHighlight.alpha > 0.0) {
+            if (oldHighlight.alpha > 0.0 && this.highlightContainer.alpha > 0.0) {
                 Tween.get(oldHighlight)
                 .to({alpha: 0.0}, 300)
                 .call(() => this.highlightContainer.removeChild(oldHighlight));
@@ -199,7 +200,7 @@ export default class BlockSprite extends PIXI.Container {
                 .to({alpha: 1.0}, 300);
             }
  
-            const toAlpha = this.isHighlighted ? 1.0 : 0.0;
+            const toAlpha = this.isHighlighted ? blockHighlight.alpha : 0.0;
             if (toAlpha !== this.highlightContainer.alpha) {
                 Tween.get(this.highlightContainer)
                 .to({alpha: toAlpha}, 300);
@@ -209,6 +210,10 @@ export default class BlockSprite extends PIXI.Container {
 
     setBlockClickedListener = (blockClickedListener: (block: Block) => void) => {
         this.blockClickedListener = blockClickedListener;
+    }
+
+    private getHighlightFrame = (): HighlightFrame => {
+        return this.hasFocus ? theme.components.block.focus : theme.components.block.highlight;
     }
 
     // clampVectorToBounds clamps the given vector's magnitude

--- a/web/src/dag/BlockSprite.ts
+++ b/web/src/dag/BlockSprite.ts
@@ -127,7 +127,7 @@ export default class BlockSprite extends PIXI.Container {
     setSize = (blockSize: number) => {
         if (!this.currentSprite.texture || this.blockSize !== blockSize) {
             this.blockSize = blockSize;
-            this.currentSprite.texture = blockTexture(this.application, blockSize, this.block.color);
+            this.currentSprite.texture = blockTexture(this.application, blockSize, this.blockColor);
 
             this.currentText = this.buildText(blockSize);
             this.textContainer.removeChildren();

--- a/web/src/dag/BlockSprite.ts
+++ b/web/src/dag/BlockSprite.ts
@@ -13,7 +13,7 @@ const blockTexture = (application: PIXI.Application, blockSize: number, blockCol
     const key = `${blockSize}-${blockColor}`
     if (!blockTextures[key]) {
         const graphics = new PIXI.Graphics();
-        graphics.lineStyle(theme.components.block[blockColor].border.width, theme.components.block[blockColor].border.color);
+        graphics.lineStyle(theme.components.block[blockColor].border.width, theme.components.block[blockColor].border.color, 1, 0.5);
         graphics.beginFill(0xffffff);
         graphics.drawRoundedRect(0, 0, blockSize, blockSize, theme.components.block.roundingRadius);
         graphics.endFill();
@@ -216,10 +216,19 @@ export default class BlockSprite extends PIXI.Container {
         return this.hasFocus ? theme.components.block.focus : theme.components.block.highlight;
     }
 
+    // getRealBlockSize returns the actual block size based on
+    // a theoretical block size, taking into account the theme properties
+    static getRealBlockSize = (blockSize: number): number => {
+        // As we have no knowledge of an actual block, we base the calculation
+        // on theme blue block, considered the most relevant
+        return (blockSize + (theme.components.block.blue.border.width / 2.0)) * theme.components.block.scale.default;
+    }
+
     // clampVectorToBounds clamps the given vector's magnitude
     // to be fully within the block's shape
     static clampVectorToBounds = (blockSize: number, vectorX: number, vectorY: number): { blockBoundsVectorX: number, blockBoundsVectorY: number } => {
-        const halfBlockSize = blockSize / 2;
+        const realBlockSize = BlockSprite.getRealBlockSize(blockSize);
+        const halfBlockSize = realBlockSize / 2;
 
         // Don't bother with any fancy calculations if the y
         // coordinate is exactly 0

--- a/web/src/dag/BlockSprite.ts
+++ b/web/src/dag/BlockSprite.ts
@@ -29,10 +29,6 @@ const blockTexture = (application: PIXI.Application, blockSize: number, blockCol
 };
 
 export default class BlockSprite extends PIXI.Container {
-    private readonly unfocusedScale = 0.9;
-    private readonly focusedScale = 1.0;
-    private readonly textSizeMultiplier = 0.25;
-
     private readonly application: PIXI.Application;
     private readonly block: Block;
     private readonly spriteContainer: PIXI.Container;
@@ -76,7 +72,7 @@ export default class BlockSprite extends PIXI.Container {
         this.currentHighlight = this.buildHighlight();
         this.highlightContainer.addChild(this.currentHighlight);
 
-        this.scale.set(this.unfocusedScale, this.unfocusedScale);
+        this.scale.set(theme.components.block.scale.default, theme.components.block.scale.default);
     }
 
     private buildSprite = (): PIXI.Sprite => {
@@ -87,10 +83,10 @@ export default class BlockSprite extends PIXI.Container {
         sprite.interactive = true;
         sprite.buttonMode = true;
         sprite.on("pointerover", () => {
-            Tween.get(this.scale).to({x: this.focusedScale, y: this.focusedScale}, 200, Ease.quadOut);
+            Tween.get(this.scale).to({x: theme.components.block.scale.hover, y: theme.components.block.scale.hover}, 200, Ease.quadOut);
         });
         sprite.on("pointerout", () => {
-            Tween.get(this.scale).to({x: this.unfocusedScale, y: this.unfocusedScale}, 200, Ease.quadOut);
+            Tween.get(this.scale).to({x: theme.components.block.scale.default, y: theme.components.block.scale.default}, 200, Ease.quadOut);
         });
         sprite.on("pointertap", () => this.blockClickedListener(this.block));
 
@@ -100,7 +96,7 @@ export default class BlockSprite extends PIXI.Container {
     private buildText = (blockSize: number): PIXI.Text => {
         const style = new PIXI.TextStyle({
             fontFamily: theme.components.block.text.fontFamily,
-            fontSize: blockSize * this.textSizeMultiplier,
+            fontSize: blockSize * theme.components.block.text.multiplier.size,
             fontWeight: theme.components.block.text.fontWeight,
             fill: theme.components.block[this.blockColor].color.contrastText,
         });
@@ -155,7 +151,7 @@ export default class BlockSprite extends PIXI.Container {
             const oldSprite = this.currentSprite;
 
             this.currentSprite = this.buildSprite();
-            this.currentSprite.texture = blockTexture(this.application, this.blockSize, this.block.color);
+            this.currentSprite.texture = blockTexture(this.application, this.blockSize, this.blockColor);
             this.currentSprite.alpha = 0.0;
             this.spriteContainer.addChild(this.currentSprite);
 

--- a/web/src/dag/BlockSprite.ts
+++ b/web/src/dag/BlockSprite.ts
@@ -13,9 +13,9 @@ const blockTexture = (application: PIXI.Application, blockSize: number, blockCol
     const key = `${blockSize}-${blockColor}`
     if (!blockTextures[key]) {
         const graphics = new PIXI.Graphics();
-        graphics.lineStyle(theme.components.block[blockColor].border.width, theme.components.block[blockColor].border.color, 1, 0.5);
+        graphics.lineStyle(theme.scale(theme.components.block[blockColor].border.width, blockSize), theme.components.block[blockColor].border.color, 1, 0.5);
         graphics.beginFill(0xffffff);
-        graphics.drawRoundedRect(0, 0, blockSize, blockSize, theme.components.block.roundingRadius);
+        graphics.drawRoundedRect(0, 0, blockSize, blockSize, theme.scale(theme.components.block.roundingRadius, blockSize));
         graphics.endFill();
 
         let textureOptions: PIXI.IGenerateTextureOptions  = {
@@ -114,11 +114,11 @@ export default class BlockSprite extends PIXI.Container {
 
     private buildHighlight = (): PIXI.Graphics => {
         const blockHighlight = this.getHighlightFrame();
-        const highlightSize = this.blockSize + blockHighlight.offset;
-        const highlightRoundingRadius = theme.components.block.roundingRadius + (blockHighlight.offset / 2);
+        const highlightSize = this.blockSize + theme.scale(blockHighlight.offset, this.blockSize);
+        const highlightRoundingRadius = theme.scale(theme.components.block.roundingRadius + (blockHighlight.offset / 2), this.blockSize);
 
         const graphics = new PIXI.Graphics();
-        graphics.lineStyle(blockHighlight.lineWidth, theme.components.block[this.highlightColor].color.highlight);
+        graphics.lineStyle(theme.scale(blockHighlight.lineWidth, this.blockSize), theme.components.block[this.highlightColor].color.highlight);
         graphics.drawRoundedRect(0, 0, highlightSize, highlightSize, highlightRoundingRadius);
         graphics.position.set(-highlightSize / 2, -highlightSize / 2);
         return graphics;
@@ -221,7 +221,7 @@ export default class BlockSprite extends PIXI.Container {
     static getRealBlockSize = (blockSize: number): number => {
         // As we have no knowledge of an actual block, we base the calculation
         // on theme blue block, considered the most relevant
-        return (blockSize + (theme.components.block.blue.border.width / 2.0)) * theme.components.block.scale.default;
+        return (blockSize + theme.scale(theme.components.block.blue.border.width / 2.0, blockSize)) * theme.components.block.scale.default;
     }
 
     // clampVectorToBounds clamps the given vector's magnitude
@@ -239,7 +239,8 @@ export default class BlockSprite extends PIXI.Container {
             };
         }
 
-        const halfBlockSizeMinusCorner = halfBlockSize - theme.components.block.roundingRadius;
+        const roundingRadius = theme.scale(theme.components.block.roundingRadius, blockSize)
+        const halfBlockSizeMinusCorner = halfBlockSize - roundingRadius;
 
         // Abs the vector's x and y before getting its tangent
         // so that it's a bit easier to reason about
@@ -273,10 +274,10 @@ export default class BlockSprite extends PIXI.Container {
         // Where:
         //   m and n are `halfBlockSizeMinusCorner`
         //   tan(α) is `tangentOfAngle`
-        //   r is `theme.components.block.roundingRadius`
+        //   r is `roundingRadius`
         const a = (tangentOfAngle ** 2) + 1;
         const b = -(2 * halfBlockSizeMinusCorner * (tangentOfAngle + 1));
-        const c = (2 * (halfBlockSizeMinusCorner ** 2)) - (theme.components.block.roundingRadius ** 2);
+        const c = (2 * (halfBlockSizeMinusCorner ** 2)) - (roundingRadius ** 2);
         const x = (-b + Math.sqrt((b ** 2) - (4 * a * c))) / (2 * a);
         const y = x * tangentOfAngle;
 

--- a/web/src/dag/Dag.ts
+++ b/web/src/dag/Dag.ts
@@ -5,6 +5,7 @@ import {getBlockChildIds} from "../model/BlocksAndEdgesAndHeightGroups"
 import {Ticker} from "@createjs/core";
 import {BlockInformation} from "../model/BlockInformation";
 import DataSource, {resolveDataSource} from "../data/DataSource";
+import { theme } from "./Theme";
 
 export default class Dag {
     private readonly headHeightMarginMultiplier = 0.25;
@@ -50,7 +51,7 @@ export default class Dag {
 
     initialize = (canvas: HTMLCanvasElement) => {
         this.application = new PIXI.Application({
-            backgroundColor: 0xeeeeee,
+            backgroundColor: theme.components.dag.backgroundColor,
             view: canvas,
             resizeTo: canvas,
             antialias: true,

--- a/web/src/dag/EdgeSprite.ts
+++ b/web/src/dag/EdgeSprite.ts
@@ -36,6 +36,7 @@ export default class EdgeSprite extends PIXI.Container {
 
     private vectorX: number = 0;
     private vectorY: number = 0;
+    private blockSize: number = 0;
     private blockBoundsVectorX: number = 0;
     private blockBoundsVectorY: number = 0;
     private isVectorInitialized: boolean = false;
@@ -79,14 +80,16 @@ export default class EdgeSprite extends PIXI.Container {
         return graphics;
     }
 
-    setVector = (vectorX: number, vectorY: number, blockBoundsVectorX: number, blockBoundsVectorY: number) => {
+    setVector = (vectorX: number, vectorY: number, blockSize: number, blockBoundsVectorX: number, blockBoundsVectorY: number) => {
         if (this.vectorX !== vectorX
             || this.vectorY !== vectorY
+            || this.blockSize !== blockSize
             || this.blockBoundsVectorX !== blockBoundsVectorX
             || this.blockBoundsVectorY !== blockBoundsVectorY) {
 
             this.vectorX = vectorX;
             this.vectorY = vectorY;
+            this.blockSize = blockSize;
             this.blockBoundsVectorX = blockBoundsVectorX;
             this.blockBoundsVectorY = blockBoundsVectorY;
 
@@ -104,9 +107,9 @@ export default class EdgeSprite extends PIXI.Container {
     }
 
     private renderGraphics = (graphics: PIXI.Graphics, definition: EdgeGraphicsDefinition) => {
-        const lineWidth = definition.lineWidth;
+        const lineWidth = theme.scale(definition.lineWidth, this.blockSize);
         const color = definition.color;
-        const arrowRadius = definition.arrowRadius;
+        const arrowRadius = theme.scale(definition.arrowRadius, this.blockSize);
 
         // Compute the edge
         const fromX = this.blockBoundsVectorX;

--- a/web/src/dag/EdgeSprite.ts
+++ b/web/src/dag/EdgeSprite.ts
@@ -108,41 +108,27 @@ export default class EdgeSprite extends PIXI.Container {
         const color = definition.color;
         const arrowRadius = definition.arrowRadius;
 
-        // Compensate for line width in block bounds vectors
-        let blockBoundsVectorX = this.blockBoundsVectorX;
-        if (blockBoundsVectorX < 0) {
-            blockBoundsVectorX += lineWidth;
-        }
-        if (blockBoundsVectorX > 0) {
-            blockBoundsVectorX -= lineWidth;
-        }
-        let blockBoundsVectorY = this.blockBoundsVectorY;
-        if (blockBoundsVectorY < 0) {
-            // noinspection JSSuspiciousNameCombination
-            blockBoundsVectorY += lineWidth;
-        }
-        if (blockBoundsVectorY > 0) {
-            // noinspection JSSuspiciousNameCombination
-            blockBoundsVectorY -= lineWidth;
-        }
+        // Compute the edge
+        const fromX = this.blockBoundsVectorX;
+        const fromY = this.blockBoundsVectorY;
+        const toX = this.vectorX - this.blockBoundsVectorX;
+        const toY = this.vectorY - this.blockBoundsVectorY;
 
-        // Draw the edge
-        const fromX = blockBoundsVectorX;
-        const fromY = blockBoundsVectorY;
-        const toX = this.vectorX - blockBoundsVectorX;
-        const toY = this.vectorY - blockBoundsVectorY;
-        graphics.clear();
-        graphics.lineStyle(lineWidth, color);
-        graphics.moveTo(fromX, fromY);
-        graphics.lineTo(toX, toY);
-
-        // Draw the arrow head
+        //Compute the arrow head
         const angleRadians = Math.atan2(this.vectorY, this.vectorX) + (Math.PI / 2);
         const toVectorMagnitude = Math.sqrt(toX ** 2 + toY ** 2);
         const arrowOffsetX = -toX * (arrowRadius + lineWidth) / toVectorMagnitude;
         const arrowOffsetY = -toY * (arrowRadius + lineWidth) / toVectorMagnitude;
         const arrowX = toX + arrowOffsetX;
         const arrowY = toY + arrowOffsetY;
+
+        // Draw the edge
+        graphics.clear();
+        graphics.lineStyle(lineWidth, color);
+        graphics.moveTo(fromX, fromY);
+        graphics.lineTo(toX + arrowOffsetX, toY + arrowOffsetY);
+
+        // Draw the arrow head
         graphics.beginFill(color);
         graphics.drawStar!(arrowX, arrowY, 3, arrowRadius, 0, angleRadians);
         graphics.endFill();

--- a/web/src/dag/EdgeSprite.ts
+++ b/web/src/dag/EdgeSprite.ts
@@ -1,16 +1,17 @@
 import '@pixi/graphics-extras';
 import * as PIXI from "pixi.js-legacy";
 import {Tween} from "@createjs/tweenjs";
+import { EdgeLayout, theme } from "./Theme";
 
 class EdgeGraphicsDefinition {
     readonly color;
     readonly lineWidth;
     readonly arrowRadius;
 
-    constructor(color: number, lineWidth: number, arrowRadius: number) {
-        this.color = color;
-        this.lineWidth = lineWidth;
-        this.arrowRadius = arrowRadius;
+    constructor(props: EdgeLayout) {
+        this.color = props.color;
+        this.lineWidth = props.lineWidth;
+        this.arrowRadius = props.arrowRadius;
     }
 
     key = (): string => {
@@ -19,13 +20,13 @@ class EdgeGraphicsDefinition {
 }
 
 export default class EdgeSprite extends PIXI.Container {
-    private static readonly normalDefinition = new EdgeGraphicsDefinition(0xaaaaaa, 2, 4);
-    private static readonly inVirtualSelectedParentChainDefinition = new EdgeGraphicsDefinition(0xb4cfed, 4, 6);
-    private static readonly highlightedParentDefinition = new EdgeGraphicsDefinition(0x6be39f, 4, 6);
-    private static readonly highlightedChildDefinition = new EdgeGraphicsDefinition(0x6be39f, 4, 6);
-    private static readonly highlightedSelectedParentDefinition = new EdgeGraphicsDefinition(0x4de3bb, 6, 8);
-    private static readonly highlightedParentInVirtualSelectedParentChainDefinition = new EdgeGraphicsDefinition(0x7ce0e6, 6, 8);
-    private static readonly highlightedChildInVirtualSelectedParentChainDefinition = new EdgeGraphicsDefinition(0x7ce0e6, 6, 8);
+    private static readonly normalDefinition = new EdgeGraphicsDefinition(theme.components.edge.normal);
+    private static readonly inVirtualSelectedParentChainDefinition = new EdgeGraphicsDefinition(theme.components.edge.virtualChain);
+    private static readonly highlightedParentDefinition = new EdgeGraphicsDefinition(theme.components.edge.highlighted.parent);
+    private static readonly highlightedChildDefinition = new EdgeGraphicsDefinition(theme.components.edge.highlighted.child);
+    private static readonly highlightedSelectedParentDefinition = new EdgeGraphicsDefinition(theme.components.edge.highlighted.selected);
+    private static readonly highlightedParentInVirtualSelectedParentChainDefinition = new EdgeGraphicsDefinition(theme.components.edge.highlighted.virtualChain.parent);
+    private static readonly highlightedChildInVirtualSelectedParentChainDefinition = new EdgeGraphicsDefinition(theme.components.edge.highlighted.virtualChain.child);
 
     private static readonly definitionMap: { [definitionKey: string]: EdgeGraphicsDefinition } = EdgeSprite.initializeDefinitionMap();
 

--- a/web/src/dag/HeightSprite.ts
+++ b/web/src/dag/HeightSprite.ts
@@ -1,5 +1,6 @@
 import * as PIXI from "pixi.js-legacy";
 import {Ease, Tween} from "@createjs/tweenjs";
+import { theme } from "./Theme";
 
 const heightTextures: { [key: string]: PIXI.RenderTexture } = {};
 
@@ -7,7 +8,7 @@ const heightTexture = (application: PIXI.Application, width: number, height: num
     const key = `${width},${height}`
     if (!heightTextures[key]) {
         const graphics = new PIXI.Graphics();
-        graphics.beginFill(0xf7f9fa);
+        graphics.beginFill(0xffffff);
         graphics.drawRect(0, 0, width, height);
         graphics.endFill();
 
@@ -22,9 +23,6 @@ const heightTexture = (application: PIXI.Application, width: number, height: num
 };
 
 export default class HeightSprite extends PIXI.Container {
-    private readonly textSizeMultiplier = 0.15;
-    private readonly textBottomMarginMultiplier = 0.5;
-
     private readonly application: PIXI.Application;
     private readonly blockHeight: number;
     private readonly spriteContainer: PIXI.Container;
@@ -65,7 +63,7 @@ export default class HeightSprite extends PIXI.Container {
         const sprite = new PIXI.Sprite();
         sprite.anchor.set(0.5, 0.5);
         sprite.alpha = 0.0;
-        sprite.tint = 0xe8e8e8;
+        sprite.tint = theme.components.height.color.highlight;
 
         sprite.interactive = true;
         sprite.buttonMode = true;
@@ -82,16 +80,17 @@ export default class HeightSprite extends PIXI.Container {
 
     private buildText = (spriteHeight: number, blockSize: number): PIXI.Text => {
         const style = new PIXI.TextStyle({
-            fontFamily: '"Verdana", "Arial", "Helvetica", sans-serif',
-            fontSize: blockSize * this.textSizeMultiplier,
+            fontFamily: theme.components.height.text.fontFamily,
+            fontWeight: theme.components.height.text.fontWeight,
+            fontSize: blockSize * theme.components.height.text.multiplier.size,
             fill: 0xffffff,
         });
 
         const language = navigator.language || "en-US";
         const text = new PIXI.Text(this.getTextValue().toLocaleString(language), style);
         text.anchor.set(0.5, 0.5);
-        text.tint = 0x777777;
-        text.y = (spriteHeight / 2) - (blockSize * this.textBottomMarginMultiplier);
+        text.tint = theme.components.height.color.contrastText;
+        text.y = (spriteHeight / 2) - (blockSize * theme.components.height.text.multiplier.bottomMargin);
         return text;
     }
 

--- a/web/src/dag/Theme.ts
+++ b/web/src/dag/Theme.ts
@@ -158,7 +158,7 @@ export const theme: Theme = {
             normal: {
                 color: 0xaaaaaa,            // Stas original: 0xaaaaaa
                 lineWidth: 2,               // Stas original: 2
-                arrowRadius: 4,             // Stas original: 4
+                arrowRadius: 4.5,           // Stas original: 4
             },
             virtualChain: {
                 color: 0x82a2cf,            // Stas original: 0xb4cfed

--- a/web/src/dag/Theme.ts
+++ b/web/src/dag/Theme.ts
@@ -50,6 +50,10 @@ export interface Theme {
 
         dag: {
             backgroundColor: number;
+            scaling: {
+                // the block size for which all components dimensions are meant
+                referenceBlockSize: number;
+            }
         }
 
         edge: {
@@ -86,6 +90,8 @@ export interface Theme {
             visibleHeightRangePadding: number;
         }
     }
+
+    scale: (measure: number, blockSize: number) => number;
 };
 
 export const theme: Theme = {
@@ -101,7 +107,7 @@ export const theme: Theme = {
                 },
                 border: {
                     color: 0xffffff,        // Stas original: 0xaaaaaa
-                    width: 3.0,             // Stas original: 3
+                    width: 2.0,             // Stas original: 3
                 },
             },
             red: {
@@ -112,7 +118,7 @@ export const theme: Theme = {
                 },
                 border: {
                     color: 0xffffff,        // Stas original: 0xaaaaaa
-                    width: 3.0,             // Stas original: 3
+                    width: 2.0,             // Stas original: 3
                 },
             },
             gray: {
@@ -123,7 +129,7 @@ export const theme: Theme = {
                 },
                 border: {
                     color: 0xaaaaaa,        // Stas original: 0xaaaaaa
-                    width: 3.0,             // Stas original: 3
+                    width: 2.0,             // Stas original: 3
                 },
             },
             focus: {
@@ -152,13 +158,16 @@ export const theme: Theme = {
 
         dag: {
             backgroundColor: 0xeeeeee,      // Stas original: 0xffffff
+            scaling: {
+                referenceBlockSize: 88,
+            },
         },
 
         edge: {
             normal: {
                 color: 0xaaaaaa,            // Stas original: 0xaaaaaa
                 lineWidth: 2,               // Stas original: 2
-                arrowRadius: 4.5,           // Stas original: 4
+                arrowRadius: 5,             // Stas original: 4
             },
             virtualChain: {
                 color: 0x82a2cf,            // Stas original: 0xb4cfed
@@ -211,7 +220,7 @@ export const theme: Theme = {
                                             // Stas original: '"Verdana", "Arial", "Helvetica", sans-serif'
                 fontWeight: "normal",       // Stas original: "normal"
                 multiplier: {
-                    size: 0.15,             // Stas original: 0.15
+                    size: 0.185,            // Stas original: 0.15
                     bottomMargin: 0.5,      // Stas original: 0.5
                 },
             },
@@ -225,4 +234,8 @@ export const theme: Theme = {
             visibleHeightRangePadding: 2,   // Stas original: 2
         },
     },
+
+    scale: (measure: number, blockSize: number): number => {
+        return measure * blockSize / theme.components.dag.scaling.referenceBlockSize;
+    }
 }

--- a/web/src/dag/Theme.ts
+++ b/web/src/dag/Theme.ts
@@ -15,6 +15,7 @@ export interface BlockLayout {
 }
 
 export interface HighlightFrame {
+    alpha: number,
     lineWidth: number
     offset: number;
 }
@@ -126,12 +127,14 @@ export const theme: Theme = {
                 },
             },
             focus: {
-                lineWidth: 8,               // Stas original: 5
-                offset: 15,                 // Stas original: 11
+                alpha: 0.6,                 // Stas original: 1.0
+                lineWidth: 10,              // Stas original: 5
+                offset: 24,                 // Stas original: 11
             },
             highlight: {
+                alpha: 0.6,                 // Stas original: 1.0
                 lineWidth: 5,               // Stas original: 5
-                offset: 11,                 // Stas original: 11
+                offset: 13,                 // Stas original: 11
             },
             scale: {
                 default: 0.9,               // Stas original: 0.9

--- a/web/src/dag/Theme.ts
+++ b/web/src/dag/Theme.ts
@@ -34,9 +34,16 @@ export interface Theme {
             gray: BlockLayout;
             focus: HighlightFrame;
             highlight: HighlightFrame;
+            scale: {
+                default: number;
+                hover: number;
+            }
             text: {
                 fontFamily: string;
                 fontWeight: TextStyleFontWeight;
+                multiplier: {
+                    size: number;
+                }
             }
         }
 
@@ -68,6 +75,14 @@ export interface Theme {
                     bottomMargin: number;
                 }
             }
+        },
+
+        timeline: {
+            maxBlocksPerHeight: number;
+            multiplier: {
+                margin: number;
+            }
+            visibleHeightRangePadding: number;
         }
     }
 };
@@ -84,8 +99,8 @@ export const theme: Theme = {
                     contrastText: 0xffffff, // Stas original: 0x666666  
                 },
                 border: {
-                    color: 0xaaaaaa,        // Stas original: 0xaaaaaa
-                    width: 0.0,             // Stas original: 2
+                    color: 0xffffff,        // Stas original: 0xaaaaaa
+                    width: 3.0,             // Stas original: 3
                 },
             },
             red: {
@@ -95,8 +110,8 @@ export const theme: Theme = {
                     contrastText: 0xffffff, // Stas original: 0x666666   
                 },
                 border: {
-                    color: 0xaaaaaa,        // Stas original: 0xaaaaaa
-                    width: 0.0,             // Stas original: 2
+                    color: 0xffffff,        // Stas original: 0xaaaaaa
+                    width: 3.0,             // Stas original: 3
                 },
             },
             gray: {
@@ -107,7 +122,7 @@ export const theme: Theme = {
                 },
                 border: {
                     color: 0xaaaaaa,        // Stas original: 0xaaaaaa
-                    width: 0.8,             // Stas original: 2
+                    width: 3.0,             // Stas original: 3
                 },
             },
             focus: {
@@ -118,10 +133,17 @@ export const theme: Theme = {
                 lineWidth: 5,               // Stas original: 5
                 offset: 11,                 // Stas original: 11
             },
+            scale: {
+                default: 0.9,               // Stas original: 0.9
+                hover: 1.0,                 // Stas original: 1.0
+            },
             text: {
                 fontFamily: 'monospace, "Lucida Console", "Courier"',
                                             // Stas original: '"Lucida Console", "Courier", monospace'
                 fontWeight: "bold",         // Stas original: "bold"
+                multiplier: {
+                    size: 0.25,             // Stas original: 0.25
+                },
             }
         },
 
@@ -190,6 +212,14 @@ export const theme: Theme = {
                     bottomMargin: 0.5,      // Stas original: 0.5
                 },
             },
+        },
+
+        timeline: {
+            maxBlocksPerHeight: 12,         // Stas original: 12
+            multiplier: {
+                margin: 2.0,                // Stas original: 2.0
+            },
+            visibleHeightRangePadding: 2,   // Stas original: 2
         },
     },
 }

--- a/web/src/dag/Theme.ts
+++ b/web/src/dag/Theme.ts
@@ -1,0 +1,195 @@
+import { TextStyleFontWeight } from "pixi.js-legacy";
+
+export interface BasePaletteColor  {
+    main: number;
+    highlight: number;
+    contrastText: number;
+}
+
+export interface BlockLayout {
+    color: BasePaletteColor;
+    border: {
+        color: number;
+        width: number;
+    }
+}
+
+export interface HighlightFrame {
+    lineWidth: number
+    offset: number;
+}
+
+export interface EdgeLayout {
+    color: number;
+    lineWidth: number;
+    arrowRadius:  number;
+}
+
+export interface Theme {
+    components: {
+        block: {
+            roundingRadius: number;
+            blue: BlockLayout;
+            red: BlockLayout;
+            gray: BlockLayout;
+            focus: HighlightFrame;
+            highlight: HighlightFrame;
+            text: {
+                fontFamily: string;
+                fontWeight: TextStyleFontWeight;
+            }
+        }
+
+        dag: {
+            backgroundColor: number;
+        }
+
+        edge: {
+            normal: EdgeLayout;
+            virtualChain: EdgeLayout;
+            highlighted: {
+                parent: EdgeLayout;
+                child: EdgeLayout;
+                selected: EdgeLayout;
+                virtualChain: {
+                    parent: EdgeLayout;
+                    child: EdgeLayout;    
+                }
+            }
+        }
+
+        height: {
+            color: BasePaletteColor;
+            text: {
+                fontFamily: string;
+                fontWeight: TextStyleFontWeight;
+                multiplier: {
+                    size: number;
+                    bottomMargin: number;
+                }
+            }
+        }
+    }
+};
+
+export const theme: Theme = {
+    components: {
+        block: {
+            roundingRadius: 10,             // Stas original: 10
+            blue: {
+                color: {
+                    main: 0x4B81BD,         // Stas original: 0xb4cfed,
+                    highlight: 0x7196c9,    // Stas original: 0x49849e
+                                            // https://fffuel.co/cccolor/ - 0x4B81BD - Tint palette 2
+                    contrastText: 0xffffff, // Stas original: 0x666666  
+                },
+                border: {
+                    color: 0xaaaaaa,        // Stas original: 0xaaaaaa
+                    width: 0.0,             // Stas original: 2
+                },
+            },
+            red: {
+                color: {
+                    main: 0xfc606f,         // Stas original: 0xfc606f
+                    highlight: 0x9e4949,    // Stas original: 0x9e4949
+                    contrastText: 0xffffff, // Stas original: 0x666666   
+                },
+                border: {
+                    color: 0xaaaaaa,        // Stas original: 0xaaaaaa
+                    width: 0.0,             // Stas original: 2
+                },
+            },
+            gray: {
+                color: {
+                    main: 0xf5faff,         // Stas original: 0xf5faff
+                    highlight: 0x78869e,    // Stas original: 0x78869e
+                    contrastText: 0x666666, // Stas original: 0x666666
+                },
+                border: {
+                    color: 0xaaaaaa,        // Stas original: 0xaaaaaa
+                    width: 0.8,             // Stas original: 2
+                },
+            },
+            focus: {
+                lineWidth: 8,               // Stas original: 5
+                offset: 15,                 // Stas original: 11
+            },
+            highlight: {
+                lineWidth: 5,               // Stas original: 5
+                offset: 11,                 // Stas original: 11
+            },
+            text: {
+                fontFamily: 'monospace, "Lucida Console", "Courier"',
+                                            // Stas original: '"Lucida Console", "Courier", monospace'
+                fontWeight: "bold",         // Stas original: "bold"
+            }
+        },
+
+        dag: {
+            backgroundColor: 0xeeeeee,      // Stas original: 0xffffff
+        },
+
+        edge: {
+            normal: {
+                color: 0xaaaaaa,            // Stas original: 0xaaaaaa
+                lineWidth: 2,               // Stas original: 2
+                arrowRadius: 4,             // Stas original: 4
+            },
+            virtualChain: {
+                color: 0x82a2cf,            // Stas original: 0xb4cfed
+                                            // https://fffuel.co/cccolor/ - 0x4B81BD - Tint palette 3
+                lineWidth: 5,               // Stas original: 4
+                arrowRadius: 7,             // Stas original: 6
+            },
+            highlighted: {
+                parent: {
+                    color: 0x6be39f,        // Stas original: 0x6be39f
+                    lineWidth: 4,           // Stas original: 4
+                    arrowRadius: 6,         // Stas original: 6
+                },
+                child: {
+                    color: 0x6be39f,        // Stas original: 0x6be39f
+                    lineWidth: 4,           // Stas original: 4
+                    arrowRadius: 6,         // Stas original: 6
+                },
+                selected: {
+                    color: 0x4de3bb,        // Stas original: 0x4de3bb
+                    lineWidth: 6,           // Stas original: 6
+                    arrowRadius: 8,         // Stas original: 8
+                },
+                virtualChain: {
+                    parent: {
+                        color: 0x195d96,    // Stas original: 0x7ce0e6,
+                                            // https://fffuel.co/cccolor/ - 0x4B81BD - Shade palette 3
+                        lineWidth: 6,       // Stas original: 6
+                        arrowRadius: 8,     // Stas original: 8
+                    },
+                    child: {
+                        color: 0x195d96,    // Stas original: 0x7ce0e6,
+                                            // https://fffuel.co/cccolor/ - 0x4B81BD - Shade palette 3
+                        lineWidth: 6,       // Stas original: 6
+                        arrowRadius: 8,     // Stas original: 8
+                    },
+                },
+            },
+        },
+
+        height: {
+            color: {
+                main: 0xf7f7f7,             // Stas original: 0xf7f9fa
+                                            // NOT USED
+                highlight: 0xe3e3e3,        // Stas original: 0xe8e8e8
+                contrastText: 0x777777,     // Stas original: 0x777777
+            },
+            text: {
+                fontFamily: '"Verdana", "Arial", "Helvetica", sans-serif',
+                                            // Stas original: '"Verdana", "Arial", "Helvetica", sans-serif'
+                fontWeight: "normal",       // Stas original: "normal"
+                multiplier: {
+                    size: 0.15,             // Stas original: 0.15
+                    bottomMargin: 0.5,      // Stas original: 0.5
+                },
+            },
+        },
+    },
+}

--- a/web/src/dag/Theme.ts
+++ b/web/src/dag/Theme.ts
@@ -100,9 +100,9 @@ export const theme: Theme = {
             roundingRadius: 10,             // Stas original: 10
             blue: {
                 color: {
-                    main: 0x4B81BD,         // Stas original: 0xb4cfed,
-                    highlight: 0x7196c9,    // Stas original: 0x49849e
-                                            // https://fffuel.co/cccolor/ - 0x4B81BD - Tint palette 2
+                    main: 0x5581AA,         // Stas original: 0xb4cfed,
+                    highlight: 0x85a2c1,    // Stas original: 0x49849e
+                                            // https://fffuel.co/cccolor/ - 0x5581AA - Tint palette 3
                     contrastText: 0xffffff, // Stas original: 0x666666  
                 },
                 border: {
@@ -112,8 +112,9 @@ export const theme: Theme = {
             },
             red: {
                 color: {
-                    main: 0xfc606f,         // Stas original: 0xfc606f
-                    highlight: 0x9e4949,    // Stas original: 0x9e4949
+                    main: 0xB34D50,         // Stas original: 0xfc606f
+                    highlight: 0xa06765,    // Stas original: 0x9e4949
+                                            // https://fffuel.co/cccolor/ - 0xB34D50 - Tone palette 5
                     contrastText: 0xffffff, // Stas original: 0x666666   
                 },
                 border: {
@@ -151,7 +152,7 @@ export const theme: Theme = {
                                             // Stas original: '"Lucida Console", "Courier", monospace'
                 fontWeight: "bold",         // Stas original: "bold"
                 multiplier: {
-                    size: 0.25,             // Stas original: 0.25
+                    size: 0.26,             // Stas original: 0.25
                 },
             }
         },
@@ -170,21 +171,23 @@ export const theme: Theme = {
                 arrowRadius: 5,             // Stas original: 4
             },
             virtualChain: {
-                color: 0x82a2cf,            // Stas original: 0xb4cfed
-                                            // https://fffuel.co/cccolor/ - 0x4B81BD - Tint palette 3
-                lineWidth: 5,               // Stas original: 4
-                arrowRadius: 7,             // Stas original: 6
+                color: 0x85a2c1,            // Stas original: 0xb4cfed
+                                            // https://fffuel.co/cccolor/ - 0x5581AA - Tint palette 3
+                lineWidth: 6,               // Stas original: 4
+                arrowRadius: 8,             // Stas original: 6
             },
             highlighted: {
                 parent: {
-                    color: 0x6be39f,        // Stas original: 0x6be39f
+                    color: 0x54ed9e,        // Stas original: 0x6be39f
+                                            // https://fffuel.co/pppalette/ - 0x5581AA - Jewel Analogous Palette 1
                     lineWidth: 4,           // Stas original: 4
-                    arrowRadius: 6,         // Stas original: 6
+                    arrowRadius: 7,         // Stas original: 6
                 },
                 child: {
-                    color: 0x6be39f,        // Stas original: 0x6be39f
+                    color: 0x54ed9e,        // Stas original: 0x6be39f
+                                            // https://fffuel.co/pppalette/ - 0x5581AA - Jewel Analogous Palette 1
                     lineWidth: 4,           // Stas original: 4
-                    arrowRadius: 6,         // Stas original: 6
+                    arrowRadius: 7,         // Stas original: 6
                 },
                 selected: {
                     color: 0x4de3bb,        // Stas original: 0x4de3bb
@@ -193,14 +196,14 @@ export const theme: Theme = {
                 },
                 virtualChain: {
                     parent: {
-                        color: 0x195d96,    // Stas original: 0x7ce0e6,
-                                            // https://fffuel.co/cccolor/ - 0x4B81BD - Shade palette 3
+                        color: 0x54edea,    // Stas original: 0x7ce0e6,
+                                            // https://fffuel.co/pppalette/ - 0x5581AA - Jewel Analogous Palette 2
                         lineWidth: 6,       // Stas original: 6
                         arrowRadius: 8,     // Stas original: 8
                     },
                     child: {
-                        color: 0x195d96,    // Stas original: 0x7ce0e6,
-                                            // https://fffuel.co/cccolor/ - 0x4B81BD - Shade palette 3
+                        color: 0x54edea,    // Stas original: 0x7ce0e6,
+                                            // https://fffuel.co/pppalette/ - 0x5581AA - Jewel Analogous Palette 2
                         lineWidth: 6,       // Stas original: 6
                         arrowRadius: 8,     // Stas original: 8
                     },

--- a/web/src/dag/TimelineContainer.ts
+++ b/web/src/dag/TimelineContainer.ts
@@ -12,7 +12,7 @@ import {
 } from "../model/BlocksAndEdgesAndHeightGroups";
 import {Edge} from "../model/Edge";
 import {HeightGroup} from "../model/HeightGroup";
-import {BlockColor} from "../model/BlockColor";
+import {BlockColorConst, BlockColor} from "../model/BlockColor";
 
 export default class TimelineContainer extends PIXI.Container {
     private readonly maxBlocksPerHeightGroup = 12;
@@ -223,7 +223,7 @@ export default class TimelineContainer extends PIXI.Container {
         blockSprite.setColor(block.color);
 
         if (targetBlockKey === null) {
-            blockSprite.setHighlighted(false);
+            blockSprite.setHighlighted(false, false, BlockColorConst.GRAY);
             return;
         }
 
@@ -234,18 +234,19 @@ export default class TimelineContainer extends PIXI.Container {
 
         const mergeSetBlockKeys = mergeSetRedBlockKeys.concat(mergeSetBlueBlockKeys);
         if (mergeSetBlockKeys.indexOf(blockKey) < 0 && blockKey !== targetBlockKey) {
-            blockSprite.setHighlighted(false);
+            blockSprite.setHighlighted(false, false, BlockColorConst.GRAY);
             return;
         }
 
-        blockSprite.setHighlighted(true);
+        var blockColor = BlockColorConst.GRAY;
         if (mergeSetRedBlockKeys.indexOf(blockKey) >= 0) {
-            blockSprite.setHighlightColor(BlockColor.RED);
+            blockColor = BlockColorConst.RED;
         } else if (mergeSetBlueBlockKeys.indexOf(blockKey) >= 0) {
-            blockSprite.setHighlightColor(BlockColor.BLUE);
+            blockColor = BlockColorConst.BLUE;
         } else {
-            blockSprite.setHighlightColor(BlockColor.GRAY);
+            blockColor = block.color as BlockColor;
         }
+        blockSprite.setHighlighted(true, blockKey === targetBlockKey, blockColor);
     }
 
     private assignEdgeToEdgeSprite = (edgeSprite: EdgeSprite, edge: Edge, targetBlockKey: string | null) => {

--- a/web/src/dag/TimelineContainer.ts
+++ b/web/src/dag/TimelineContainer.ts
@@ -13,12 +13,9 @@ import {
 import {Edge} from "../model/Edge";
 import {HeightGroup} from "../model/HeightGroup";
 import {BlockColorConst, BlockColor} from "../model/BlockColor";
+import { theme } from "./Theme";
 
 export default class TimelineContainer extends PIXI.Container {
-    private readonly maxBlocksPerHeightGroup = 12;
-    private readonly marginMultiplier = 2.0;
-    private readonly visibleHeightRangePadding: number = 2;
-
     private readonly application: PIXI.Application;
     private readonly heightContainer: PIXI.Container;
     private readonly edgeContainer: PIXI.Container;
@@ -472,11 +469,11 @@ export default class TimelineContainer extends PIXI.Container {
     }
 
     private calculateBlockSize = (rendererHeight: number): number => {
-        return Math.floor(rendererHeight / this.maxBlocksPerHeightGroup);
+        return Math.floor(rendererHeight / theme.components.timeline.maxBlocksPerHeight);
     }
 
     private calculateMargin = (blockSize: number): number => {
-        return blockSize * this.marginMultiplier;
+        return blockSize * theme.components.timeline.multiplier.margin;
     }
 
     recalculatePositions = () => {
@@ -525,7 +522,7 @@ export default class TimelineContainer extends PIXI.Container {
         const margin = this.calculateMargin(blockSize);
 
         const maxBlockAmountOnScreen = rendererWidth / (blockSize + margin);
-        return Math.ceil(maxBlockAmountOnScreen / 2) + this.visibleHeightRangePadding;
+        return Math.ceil(maxBlockAmountOnScreen / 2) + theme.components.timeline.visibleHeightRangePadding;
     }
 
     setTargetHeight = (targetHeight: number, newData?: BlocksAndEdgesAndHeightGroups) => {

--- a/web/src/dag/TimelineContainer.ts
+++ b/web/src/dag/TimelineContainer.ts
@@ -425,7 +425,7 @@ export default class TimelineContainer extends PIXI.Container {
             blockBoundsVectorY
         } = BlockSprite.clampVectorToBounds(blockSize, vectorX, vectorY);
 
-        edgeSprite.setVector(vectorX, vectorY, blockBoundsVectorX, blockBoundsVectorY);
+        edgeSprite.setVector(vectorX, vectorY, blockSize, blockBoundsVectorX, blockBoundsVectorY);
         edgeSprite.setToY(toY);
 
         edgeSprite.x = fromX;

--- a/web/src/data/ChainDataSource.ts
+++ b/web/src/data/ChainDataSource.ts
@@ -2,7 +2,7 @@ import DataSource from "./DataSource";
 import {BlocksAndEdgesAndHeightGroups} from "../model/BlocksAndEdgesAndHeightGroups";
 import {BlockHashById} from "../model/BlockHashById";
 import {Block} from "../model/Block";
-import {BlockColor} from "../model/BlockColor";
+import {BlockColorConst} from "../model/BlockColor";
 import {Edge} from "../model/Edge";
 import {HeightGroup} from "../model/HeightGroup";
 
@@ -35,7 +35,7 @@ export default class ChainDataSource implements DataSource {
             daaScore: nextBlockId,
             heightGroupIndex: 0,
             selectedParentId: lastBlockId,
-            color: BlockColor.BLUE,
+            color: BlockColorConst.BLUE,
             isInVirtualSelectedParentChain: true,
             mergeSetRedIds: [],
             mergeSetBlueIds: [lastBlockId],
@@ -121,7 +121,7 @@ export default class ChainDataSource implements DataSource {
             daaScore: 0,
             heightGroupIndex: 0,
             selectedParentId: null,
-            color: BlockColor.BLUE,
+            color: BlockColorConst.BLUE,
             isInVirtualSelectedParentChain: true,
             mergeSetRedIds: [],
             mergeSetBlueIds: [],

--- a/web/src/data/ReplayDataSource.ts
+++ b/web/src/data/ReplayDataSource.ts
@@ -4,6 +4,7 @@ import {BlockHashById} from "../model/BlockHashById";
 import {Block} from "../model/Block";
 import {Edge} from "../model/Edge";
 import {HeightGroup} from "../model/HeightGroup";
+import { BlockColor } from "../model/BlockColor";
 
 export type ReplayData = {
     blocks: ReplayDataBlock[],
@@ -14,7 +15,7 @@ export type ReplayDataBlock = {
     id: number,
     parentIds: number[],
     selectedParentId: number | null,
-    color: string,
+    color: BlockColor,
     isInVirtualSelectedParentChain: boolean,
     mergeSetRedIds: number[],
     mergeSetBlueIds: number[],

--- a/web/src/model/Block.ts
+++ b/web/src/model/Block.ts
@@ -1,3 +1,5 @@
+import { BlockColor } from "./BlockColor";
+
 export type Block = {
     id: number,
     blockHash: string,
@@ -7,7 +9,7 @@ export type Block = {
     daaScore: number,
     heightGroupIndex: number,
     selectedParentId: number | null,
-    color: string,
+    color: BlockColor,
     isInVirtualSelectedParentChain: boolean,
     mergeSetRedIds: number[],
     mergeSetBlueIds: number[],

--- a/web/src/model/BlockColor.ts
+++ b/web/src/model/BlockColor.ts
@@ -1,4 +1,14 @@
-export const BlockColor = {
+import { BlockColor as BaseBlockColor } from "../types/Base";
+
+export type BlockColor = BaseBlockColor;
+
+interface BlockColorConstDefinition {
+    GRAY: BlockColor;
+    RED: BlockColor;
+    BLUE: BlockColor;
+}
+
+export const BlockColorConst: BlockColorConstDefinition = {
     GRAY: "gray",
     RED: "red",
     BLUE: "blue",

--- a/web/src/types/Base.ts
+++ b/web/src/types/Base.ts
@@ -1,0 +1,3 @@
+export {};
+
+export type BlockColor = "blue" | "red" | "gray";

--- a/web/src/types/createPalette.d.ts
+++ b/web/src/types/createPalette.d.ts
@@ -1,17 +1,22 @@
 import '@mui/material/styles/createPalette';
+import { BlockColor as BaseBlockColor } from "./Base";
 
 declare module '@mui/material/styles/createPalette' {
-    interface PaletteOptions {    
-        blueBlock?: PaletteColorOptions;
-        redBlock?: PaletteColorOptions;
-        newBlock?: PaletteColorOptions;
+    interface PaletteOptions {
+        block: {
+            blue?: PaletteColorOptions;
+            red?: PaletteColorOptions;
+            gray?: PaletteColorOptions;
+        }    
     }
 
     interface Palette {
-        blueBlock: PaletteColor;
-        redBlock: PaletteColor;
-        newBlock: PaletteColor;
+        block: {
+            blue: PaletteColor;
+            red: PaletteColor;
+            gray: PaletteColor;
+        }
     }
 
-    type BlockColor = "blueBlock" | "redBlock" | "newBlock" | undefined
+    type BlockColor = BaseBlockColor
 }


### PR DESCRIPTION
- New palette of **block colors**, used consistently everywhere
- The DAG layout is defined by a **theme** instead of in-code constants
- In the DAG visualisation, the **edges are now pixel-perfectly touching** their from- and to- blocks
- The **DAG get scaled** in function of the viewport height not only for block size and timeline but also for edges and for all of its visual properties, including borders, line widths, block square radius, highlights, arrows
- This gives the **DAG an overall fluid responsiveness**
- The **block information panel** gets a revamp:
   - White background
   - Smaller fonts
   - Some CSS adjustments
- Though far from perfect, **UX is enhanced for mobile users**