### PR TITLE
Add support for SSL/https to API

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,15 +1,17 @@
 {
   "name": "api",
-  "version": "0.1.0",
+  "version": "0.1.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "api",
-      "version": "0.1.0",
+      "version": "0.1.17",
       "dependencies": {
         "cors": "2.8.5",
         "express": "4.17.1",
+        "fs": "^0.0.1-security",
+        "https": "^1.0.0",
         "pg": "8.5.1"
       },
       "devDependencies": {
@@ -328,6 +330,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs": {
+      "version": "0.0.1-security",
+      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
+      "integrity": "sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w=="
+    },
     "node_modules/http-errors": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
@@ -342,6 +349,11 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/https": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https/-/https-1.0.0.tgz",
+      "integrity": "sha512-4EC57ddXrkaF0x83Oj8sM6SLQHAWXw90Skqu2M4AEWENZ3F02dFJE/GARA8igO79tcgYqGrD7ae4f5L3um2lgg=="
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
@@ -1068,6 +1080,11 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
+    "fs": {
+      "version": "0.0.1-security",
+      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
+      "integrity": "sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w=="
+    },
     "http-errors": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
@@ -1079,6 +1096,11 @@
         "statuses": ">= 1.5.0 < 2",
         "toidentifier": "1.0.0"
       }
+    },
+    "https": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https/-/https-1.0.0.tgz",
+      "integrity": "sha512-4EC57ddXrkaF0x83Oj8sM6SLQHAWXw90Skqu2M4AEWENZ3F02dFJE/GARA8igO79tcgYqGrD7ae4f5L3um2lgg=="
     },
     "iconv-lite": {
       "version": "0.4.24",

--- a/api/package.json
+++ b/api/package.json
@@ -5,6 +5,8 @@
   "dependencies": {
     "cors": "2.8.5",
     "express": "4.17.1",
+    "fs": "^0.0.1-security",
+    "https": "^1.0.0",
     "pg": "8.5.1"
   },
   "scripts": {

--- a/web/src/addresses.ts
+++ b/web/src/addresses.ts
@@ -1,9 +1,14 @@
+// Environment variables are used for configuring the application.
+// They define the adresses of the 3 components that are targets of queries.
+// A variable must contain a host and optionnaly a port and/or a protocol.
+
 const resolveAddress = (environmentVariableName: string): string => {
     const address = process.env[environmentVariableName];
     if (!address) {
         throw new Error(`The ${environmentVariableName} environment variable is required`);
     }
-    return `${window.location.protocol}//${address}`;
+    const prefix = address.includes("//") ? "" : `${window.location.protocol}//`;
+    return `${prefix}${address}`;
 };
 
 const apiAddress = resolveAddress("REACT_APP_API_ADDRESS");


### PR DESCRIPTION
Add some tweaks to support https directly from within API.

To enable https in API, set the following new environment variables before launching the API tier:

1. API_PROTOCOL=https
2. API_CERT=/path/to/fullchain.pem
3. API_KEY=/path/to/privkey.pem

In this case, the web tier should be hosted with https enabled, otherwise both tiers won't be able to communicate with each other. The link to Katnip, on the contrary may be kept in http if needed. In this case, the `REACT_APP_KATNIP_ADDRESS` should define the protocol explicitly (i.e. REACT_APP_KATNIP_ADDRESS=http://katnip.kaspanet.org).

This feature is designed for development and some edge cases only. It is not recommended for the deployment on a production site. Instead, an architecture based on a reverse proxy (for instance NGNIX) should be favored.