### PR TITLE
Add support for high resolution displays

### DIFF
--- a/web/public/index.html
+++ b/web/public/index.html
@@ -2,7 +2,8 @@
 <html lang="en">
 <head>
     <meta charset="utf-8"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1, minimum-scale=1"/>
+    <meta name="apple-mobile-web-app-capable" content="yes">
     <link rel="icon" type="image/png" href="%PUBLIC_URL%/favicon.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="%PUBLIC_URL%/apple-touch-icon.png" />
     <link

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -47,8 +47,6 @@ const App = ({interactive}: {interactive: boolean}) => {
         setBlockInformationPanelCloseRequested(!block);
     });
 
-    console.log(`Starting KGI: interactive=${interactive}`)
-
     return (
         <StyledEngineProvider injectFirst>
             <ThemeProvider theme={theme}>

--- a/web/src/dag/BlockSprite.ts
+++ b/web/src/dag/BlockSprite.ts
@@ -10,7 +10,8 @@ import { HighlightFrame, theme } from "./Theme";
 const blockTextures: { [key: string]: PIXI.RenderTexture } = {};
 
 const blockTexture = (application: PIXI.Application, blockSize: number, blockColor: BlockColor): PIXI.RenderTexture => {
-    const key = `${blockSize}-${blockColor}`
+    const resolution = application.renderer.resolution;
+    const key = `${blockSize}-${blockColor}-${resolution}`
     if (!blockTextures[key]) {
         const graphics = new PIXI.Graphics();
         graphics.lineStyle(theme.scale(theme.components.block[blockColor].border.width, blockSize), theme.components.block[blockColor].border.color, 1, 0.5);
@@ -20,7 +21,7 @@ const blockTexture = (application: PIXI.Application, blockSize: number, blockCol
 
         let textureOptions: PIXI.IGenerateTextureOptions  = {
             scaleMode: PIXI.SCALE_MODES.LINEAR,
-            resolution: 1,
+            resolution: resolution,
         }
         blockTextures[key] = application.renderer.generateTexture(graphics, textureOptions);
     }

--- a/web/src/dag/HeightSprite.ts
+++ b/web/src/dag/HeightSprite.ts
@@ -5,7 +5,8 @@ import { theme } from "./Theme";
 const heightTextures: { [key: string]: PIXI.RenderTexture } = {};
 
 const heightTexture = (application: PIXI.Application, width: number, height: number): PIXI.RenderTexture => {
-    const key = `${width},${height}`
+    const resolution = application.renderer.resolution;
+    const key = `${width},${height}-${resolution}`
     if (!heightTextures[key]) {
         const graphics = new PIXI.Graphics();
         graphics.beginFill(0xffffff);
@@ -14,7 +15,7 @@ const heightTexture = (application: PIXI.Application, width: number, height: num
 
         let textureOptions: PIXI.IGenerateTextureOptions  = {
             scaleMode: PIXI.SCALE_MODES.LINEAR,
-            resolution: 1,
+            resolution: resolution,
         }
         heightTextures[key] = application.renderer.generateTexture(graphics, textureOptions);
     }

--- a/web/src/dag/TimelineContainer.ts
+++ b/web/src/dag/TimelineContainer.ts
@@ -325,7 +325,7 @@ export default class TimelineContainer extends PIXI.Container {
     }
 
     private recalculateHeightSpritePositions = () => {
-        const rendererHeight = this.application.renderer.height;
+        const rendererHeight = this.getDisplayHeight();
         const blockSize = this.calculateBlockSize(rendererHeight);
         const margin = this.calculateMargin(blockSize);
 
@@ -340,7 +340,7 @@ export default class TimelineContainer extends PIXI.Container {
     }
 
     private recalculateBlockSpritePositions = (animate: boolean) => {
-        const rendererHeight = this.application.renderer.height;
+        const rendererHeight = this.getDisplayHeight();
         const blockSize = this.calculateBlockSize(rendererHeight);
         const margin = this.calculateMargin(blockSize);
 
@@ -366,7 +366,7 @@ export default class TimelineContainer extends PIXI.Container {
     }
 
     private recalculateEdgeSpritePositions = (animate: boolean) => {
-        const rendererHeight = this.application.renderer.height;
+        const rendererHeight = this.getDisplayHeight();
         const blockSize = this.calculateBlockSize(rendererHeight);
         const margin = this.calculateMargin(blockSize);
 
@@ -495,8 +495,8 @@ export default class TimelineContainer extends PIXI.Container {
     }
 
     private moveTimelineContainer = () => {
-        const rendererWidth = this.application.renderer.width;
-        const rendererHeight = this.application.renderer.height;
+        const rendererWidth = this.getDisplayWidth();
+        const rendererHeight = this.getDisplayHeight();
         const blockSize = this.calculateBlockSize(rendererHeight);
         const margin = this.calculateMargin(blockSize);
 
@@ -529,8 +529,8 @@ export default class TimelineContainer extends PIXI.Container {
     }
 
     getMaxBlockAmountOnHalfTheScreen = (): number => {
-        const rendererWidth = this.application.renderer.width;
-        const rendererHeight = this.application.renderer.height;
+        const rendererWidth = this.getDisplayWidth();
+        const rendererHeight = this.getDisplayHeight();
         const blockSize = this.calculateBlockSize(rendererHeight);
         const margin = this.calculateMargin(blockSize);
 
@@ -539,8 +539,8 @@ export default class TimelineContainer extends PIXI.Container {
     }
 
     getVisibleSlotAmountAfterHalfTheScreen = (rightMargin: number): number => {
-        const rendererWidth = this.application.renderer.width;
-        const rendererHeight = this.application.renderer.height;
+        const rendererWidth = this.getDisplayWidth();
+        const rendererHeight = this.getDisplayHeight();
         const blockSize = this.calculateBlockSize(rendererHeight);
         const margin = this.calculateMargin(blockSize);
         const heightWidth = blockSize + margin;
@@ -559,6 +559,9 @@ export default class TimelineContainer extends PIXI.Container {
     }
 
     getTargetHeight = () => this.targetHeight;
+
+    getDisplayHeight = () => this.application.renderer.screen.height;
+    getDisplayWidth = () => this.application.renderer.screen.width;
 
     setTargetDAAScore = (targetDAAScore: number) => {
         this.targetDAAScore = targetDAAScore;


### PR DESCRIPTION
Handle `window.displayPixelRatio`, alias resolution x2, x3, etc., when rendering the DAG.