### PR TITLE
Custom PostgreSQL configuration for API server endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,13 @@ Deployment
    3. Run: `kgi-processing --connection-string=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}?sslmode=disable`
 6. Run `api`
    1. Navigate to wherever you copied `api` to
-   2. Run: `npm run start`
+   2. Set the following environment variables:
+      1. POSTGRES_USER=username - which is the username for database connection.
+      2. POSTGRES_PASSWORD=password - which is the password for database connection.
+      3. POSTGRES_DB=database-name - which is the database to be used.
+      4. POSTGRES_HOST=database.example.com (optional) - which is the host of the database server (default: localhost).
+      5. POSTGRES_PORT=5432 (optional) - which is the port for database connection (default: 5432).
+   3. Run: `npm run start`
 7. Run `web`
    1. Navigate to wherever you copied `web` to
    2. Run: `npm install -g serve`

--- a/api/src/database.ts
+++ b/api/src/database.ts
@@ -2,11 +2,38 @@ import pg from "pg";
 import {AppConfig, Block, BlockHashById, BlocksAndEdgesAndHeightGroups, Edge, HeightGroup} from "./model";
 import { packageVersion } from "./version.js";
 
+/* database environment. */
+const postgres_user = process.env.POSTGRES_USER;
+const postgres_password = process.env.POSTGRES_PASSWORD;
+const postgres_host = process.env.POSTGRES_HOST ?? "localhost";
+const postgres_port = process.env.POSTGRES_PORT ?? "5432";
+const postgres_database = process.env.POSTGRES_DB;
+
+/* missing check. */
+if (!postgres_user) {
+    console.log("The POSTGRES_USER environment variable is required");
+    process.exit(1);
+}
+if (!postgres_password) {
+    console.log("The POSTGRES_PASSWORD environment variable is required");
+    process.exit(1);
+}
+if (!postgres_database) {
+    console.log("The POSTGRES_DB environment variable is required");
+    process.exit(1);
+}
+
 export default class Database {
     private pool: pg.Pool;
 
     constructor() {
-        this.pool = new pg.Pool();
+        this.pool = new pg.Pool({
+            user: postgres_user,
+            password: postgres_password,
+            host: postgres_host,
+            port: parseInt(postgres_port),
+            database: postgres_database,
+        });
     }
 
     withClient = async (func: (client: pg.PoolClient) => Promise<void>) => {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,11 +25,9 @@ services:
     depends_on:
       - postgres
     environment:
-      - PGUSER=${POSTGRES_USER}
-      - PGPASSWORD=${POSTGRES_PASSWORD}
-      - PGDATABASE=${POSTGRES_DB}
-      - PGHOST=localhost
-      - PGPORT=5432
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=${POSTGRES_DB}
       - API_PORT=${API_PORT}
     command:
       - "npm"


### PR DESCRIPTION
The current configuration of the KGI API server presumes that the PostgreSQL database is hosted on the same machine as the API server, with both the API service and the PostgreSQL database being operated by the same system user. To enhance flexibility, this PR introduces a set of environment variables:

* POSTGRES_USER: mandatory setting to define the username for database connection.
* POSTGRES_PASSWORD: mandatory setting to define the password for database connection.
* POSTGRES_DB: mandatory setting to define which database should be used.
* POSTGRES_HOST: optional setting to define the host of the database server (default: localhost).
* POSTGRES_PORT: optional setting to define the port for database connection (default: 5432).