### PR TITLE
Improvements for having a dark color palette in a future KGI version

### DIFF
--- a/web/src/components/base/AnimatedItem.tsx
+++ b/web/src/components/base/AnimatedItem.tsx
@@ -5,13 +5,14 @@ import { useSpring, animated } from '@react-spring/web'
 const AnimatedPaper = animated(props => <Paper {...props}/>);
 
 interface AnimatedItemProps {
+    backgroundColor: string;
     borderRadius: string;
     magnify: number;
     children: ReactElement
 }
 
 
-const AnimatedItem = ( {borderRadius, magnify, children}: AnimatedItemProps ) => {
+const AnimatedItem = ( {backgroundColor, borderRadius, magnify, children}: AnimatedItemProps ) => {
     const [active, toggle] = useState(false)
     const { x } = useSpring({
         from: { x: 0 },
@@ -32,6 +33,7 @@ const AnimatedItem = ( {borderRadius, magnify, children}: AnimatedItemProps ) =>
                 scale: x.to({range: [0, 1], output: [1, magnify] }),
                 borderRadius: borderRadius,
                 cursor: "pointer",
+                backgroundColor: backgroundColor,
             }}
         >
             {children}

--- a/web/src/components/sidebar/ConnectionIssuesIndicator.tsx
+++ b/web/src/components/sidebar/ConnectionIssuesIndicator.tsx
@@ -14,7 +14,7 @@ const ConnectionIssuesIndicator = React.forwardRef<typeof Box, ConnectionIssuesI
         const theme = useTheme();
         return (
             <Box ref={ref}>
-                <AnimatedItem borderRadius={"50%"} magnify={1.05}>
+                <AnimatedItem borderRadius={"50%"} magnify={1.05} backgroundColor={theme.palette.primary.main}>
                     <Tooltip title="Connection is unstable" placement="left" arrow enterDelay={theme.transitions.duration.enteringScreen*1.5}>
                         <Box sx={{
                                 backgroundColor: 'warning.light',

--- a/web/src/components/sidebar/KaspaButton.tsx
+++ b/web/src/components/sidebar/KaspaButton.tsx
@@ -20,7 +20,7 @@ const KaspaLogo = ({ appConfig }: {appConfig: AppConfig | null}) => {
     }
 
     return (
-        <AnimatedItem borderRadius={"50px"} magnify={1.03}>
+        <AnimatedItem borderRadius={"50px"} magnify={1.03} backgroundColor={theme.palette.primary.main}>
             <Tooltip
                 title={
                     <Box sx={{

--- a/web/src/components/sidebar/ScaleButtons.tsx
+++ b/web/src/components/sidebar/ScaleButtons.tsx
@@ -24,7 +24,7 @@ const ScaleButtons = React.forwardRef<typeof Box, ScaleButtonsProps>(
                 ref={ref}
                 sx={{ minHeight: '72px' }}
             >
-                <AnimatedItem borderRadius={"4px"} magnify={1.05}>
+                <AnimatedItem borderRadius={"4px"} magnify={1.05} backgroundColor={theme.palette.primary.main}>
                     <ButtonGroup
                         variant="text"
                         orientation="vertical"

--- a/web/src/components/sidebar/SearchButton.tsx
+++ b/web/src/components/sidebar/SearchButton.tsx
@@ -15,7 +15,7 @@ const SearchButton = React.forwardRef<typeof Box, SearchButtonProps>(
         const theme = useTheme();
         return (
             <Box ref={ref}>
-                <AnimatedItem borderRadius={"50px"} magnify={1.08}>
+                <AnimatedItem borderRadius={"50px"} magnify={1.08} backgroundColor={theme.palette.primary.main}>
                     <Tooltip title="Search the DAG" placement="left" arrow enterDelay={theme.transitions.duration.enteringScreen*1.5}>
                         <Box
                             sx={{

--- a/web/src/components/sidebar/TrackButton.tsx
+++ b/web/src/components/sidebar/TrackButton.tsx
@@ -17,7 +17,7 @@ const TrackButton = React.forwardRef<typeof Box, TrackButtonProps>(
         const theme = useTheme();
         return (
             <Box ref={ref}>
-                <AnimatedItem borderRadius={"50px"} magnify={1.08}>
+                <AnimatedItem borderRadius={"50px"} magnify={1.08} backgroundColor={theme.palette.primary.main}>
                     <Tooltip
                         title={ isTracking ? "Pause on current DAA score" : "Track DAG tips" }
                         placement="left"


### PR DESCRIPTION
This pull requests adds `backgroundColor` property to `<AnimatedItem>`. It is necessary to add another property to the `<AnimatedItem>` as otherwise the buttons look bad with a dark color palette which is a darker than original Kaspa one.

| Original | Dark | Dark with fix |
|:------|:------|:------|
| ![image](https://github.com/kaspa-live/kaspa-graph-inspector/assets/151453086/feef0105-e6bd-4dc1-90be-8dcc766c1665) | ![image](https://github.com/kaspa-live/kaspa-graph-inspector/assets/151453086/43f54171-f8cd-46a5-a451-95d857841667) | ![image](https://github.com/kaspa-live/kaspa-graph-inspector/assets/151453086/150ab63b-c90f-421b-98e1-345bd7b6bd61) |